### PR TITLE
HDDS-14661. Complete MPU parts-table split (2/N): write parts on commit

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartPartInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartPartInfo.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om.helpers;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileEncryptionInfo;
@@ -70,9 +69,10 @@ public final class OmMultipartPartInfo {
     if (b.partNumber <= 0) {
       throw new IllegalArgumentException("partNumber is required and > 0");
     }
-    if (StringUtils.isBlank(b.eTag)) {
-      throw new IllegalArgumentException("eTag is required");
-    }
+    // eTag is intentionally optional: parts committed through the native Ozone
+    // client MPU path (and pre-HDDS-9680 legacy data) carry no eTag, mirroring
+    // the schemaVersion 0 inline path. Block locations remain required -- a
+    // committed part always has data, and Complete reads its first location.
     if (b.keyLocationInfos == null || b.keyLocationInfos.isEmpty()) {
       throw new IllegalArgumentException("keyLocationList is required");
     }
@@ -151,10 +151,11 @@ public final class OmMultipartPartInfo {
     }
 
     public Builder setETag(String eTagValue) {
-      if (StringUtils.isBlank(eTagValue)) {
-        throw new IllegalArgumentException("eTag is required");
-      }
-      this.eTag = eTagValue;
+      // Optional: a blank/absent eTag is canonically stored as null so that
+      // every reader agrees -- toOmKeyInfo (eTag != null), getProto and
+      // getFromProto (isNotBlank) must not diverge on an empty-string eTag,
+      // which would otherwise leak an ETAG="" into the in-memory part key.
+      this.eTag = StringUtils.isBlank(eTagValue) ? null : eTagValue;
       return this;
     }
 
@@ -187,9 +188,16 @@ public final class OmMultipartPartInfo {
         .setPartNumber(multipartPartInfo.getPartNumber())
         .setDataSize(multipartPartInfo.getDataSize())
         .setModificationTime(multipartPartInfo.getModificationTime())
-        .setETag(multipartPartInfo.getETag())
         .setKeyLocationInfos(getKeyLocationInfosFromProto(multipartPartInfo))
         .setEncInfo(null);
+
+    // eTag is optional: only set it when the persisted row actually carries one
+    // (the native-client / legacy v0 path stores none). Leaving it null keeps
+    // toOmKeyInfo from emitting an empty ETAG and matches the inline path.
+    if (multipartPartInfo.hasETag()
+        && StringUtils.isNotBlank(multipartPartInfo.getETag())) {
+      builder.setETag(multipartPartInfo.getETag());
+    }
 
     if (!multipartPartInfo.hasObjectID()) {
       LOG.warn("MultipartPartInfo missing objectID for part {}",
@@ -239,9 +247,13 @@ public final class OmMultipartPartInfo {
         .setDataSize(dataSize)
         .setModificationTime(modificationTime)
         .setObjectID(objectID)
-        .setUpdateID(updateID)
-        .setETag(Objects.requireNonNull(eTag, "eTag is required"));
+        .setUpdateID(updateID);
 
+    // eTag is optional (see constructor note); omit it when absent. The proto
+    // field is `optional string eTag`, so absence round-trips cleanly.
+    if (StringUtils.isNotBlank(eTag)) {
+      builder.setETag(eTag);
+    }
     if (encInfo != null) {
       builder.setFileEncryptionInfo(OMPBHelper.convert(encInfo));
     }
@@ -359,9 +371,7 @@ public final class OmMultipartPartInfo {
     if (!partInfo.hasPartNumber()) {
       throw new IllegalArgumentException("MultipartPartInfo missing partNumber");
     }
-    if (!partInfo.hasETag() || StringUtils.isBlank(partInfo.getETag())) {
-      throw new IllegalArgumentException("MultipartPartInfo missing eTag");
-    }
+    // eTag is optional (native-client / legacy v0 parts carry none).
     if (!partInfo.hasKeyLocationList()) {
       throw new IllegalArgumentException("MultipartPartInfo missing keyLocationList");
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartPartInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartPartInfo.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileEncryptionInfo;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.DelegatedCodec;
 import org.apache.hadoop.hdds.utils.db.Proto2Codec;
@@ -310,6 +311,31 @@ public final class OmMultipartPartInfo {
         .setFileChecksum(omKeyInfo.getFileChecksum())
         .setETag(omKeyInfo.getMetadata().get(OzoneConsts.ETAG));
     return builder.build();
+  }
+
+  /**
+   * Reconstruct this committed part as an {@link OmKeyInfo} for quota
+   * accounting and block cleanup. The part row stores no volume/bucket/key or
+   * replication config (those live on the parent multipart upload), so the
+   * caller supplies them. The result mirrors the part key the legacy inline
+   * path keeps in MultipartKeyInfo, so quota deltas and deleted-table entries
+   * match the schemaVersion 0 behavior for the same blocks.
+   */
+  public OmKeyInfo toOmKeyInfo(String volumeName, String bucketName,
+      String keyName, ReplicationConfig replicationConfig) {
+    return new OmKeyInfo.Builder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setReplicationConfig(replicationConfig)
+        .setOmKeyLocationInfos(keyLocationInfos)
+        .setDataSize(dataSize)
+        .setCreationTime(modificationTime)
+        .setModificationTime(modificationTime)
+        .setObjectID(objectID)
+        .setUpdateID(updateID)
+        .setFileEncryptionInfo(encInfo)
+        .build();
   }
 
   private KeyLocationList getKeyLocationInfosAsProto() {

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartPartInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartPartInfo.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.ozone.om.helpers;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
@@ -64,8 +66,6 @@ public class TestOmMultipartPartInfo {
     assertThrows(IllegalArgumentException.class,
         () -> OmMultipartPartInfo.getFromProto(base.toBuilder().clearPartNumber().build()));
     assertThrows(IllegalArgumentException.class,
-        () -> OmMultipartPartInfo.getFromProto(base.toBuilder().clearETag().build()));
-    assertThrows(IllegalArgumentException.class,
         () -> OmMultipartPartInfo.getFromProto(base.toBuilder().clearKeyLocationList().build()));
     assertThrows(IllegalArgumentException.class,
         () -> OmMultipartPartInfo.getFromProto(base.toBuilder().clearDataSize().build()));
@@ -86,10 +86,36 @@ public class TestOmMultipartPartInfo {
   }
 
   @Test
-  public void testFromOmKeyInfoRejectsMissingETag() {
+  public void testFromOmKeyInfoAllowsMissingETag() {
+    // eTag is optional at schemaVersion 1: native-client / pre-HDDS-9680 parts
+    // carry none and must be stored (mirroring the inline v0 path), not rejected.
     OmKeyInfo keyInfo = createOmKeyInfoWithoutEtag();
-    assertThrows(IllegalArgumentException.class,
-        () -> OmMultipartPartInfo.from("part-name", 1, keyInfo));
+    OmMultipartPartInfo info = OmMultipartPartInfo.from("part-name", 1, keyInfo);
+    assertNull(info.getETag());
+  }
+
+  @Test
+  public void testGetFromProtoAllowsMissingETag() {
+    // An eTag-less part row round-trips: deserialize yields a null eTag and
+    // re-serializing omits the optional ETAG field entirely.
+    MultipartPartInfo proto = createValidProto().toBuilder().clearETag().build();
+    OmMultipartPartInfo decoded = OmMultipartPartInfo.getFromProto(proto);
+    assertNull(decoded.getETag());
+    assertFalse(decoded.getProto().hasETag());
+  }
+
+  @Test
+  public void testBlankETagNormalizedToNull() {
+    // A blank (empty-string) eTag is canonically stored as null, so every
+    // reader agrees: no ETAG="" leaks into the reconstructed key, matching the
+    // inline (schemaVersion 0) path and the persisted-proto round-trip.
+    OmMultipartPartInfo info = OmMultipartPartInfo.from(
+        "part-name", 1, createOmKeyInfoWithEtag(""));
+    assertNull(info.getETag());
+    assertFalse(info.toOmKeyInfo("vol", "bucket", "key",
+            RatisReplicationConfig.getInstance(THREE))
+        .getMetadata().containsKey(OzoneConsts.ETAG));
+    assertFalse(info.getProto().hasETag());
   }
 
   private static MultipartPartInfo createValidProto() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -41,6 +41,8 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -201,18 +203,52 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
           OMException.ResultCodes.NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION);
       }
 
-      oldPartKeyInfo = multipartKeyInfo.getPartKeyInfo(partNumber);
+      // Resolve the previously-committed part (if this part number is being
+      // re-committed) as an OmKeyInfo so its blocks can be reclaimed, and stage
+      // the new part. schemaVersion 0 keeps parts inline in multipartKeyInfo;
+      // schemaVersion 1 stores each part in the split parts table.
+      OmKeyInfo oldCommittedPart = null;
+      OmMultipartPartKey partsTableKey = null;
+      OmMultipartPartInfo newPartInfo = null;
+      if (multipartKeyInfo.getSchemaVersion() == 0) {
+        oldPartKeyInfo = multipartKeyInfo.getPartKeyInfo(partNumber);
+        if (oldPartKeyInfo != null) {
+          oldCommittedPart =
+              OmKeyInfo.getFromProtobuf(oldPartKeyInfo.getPartKeyInfo());
+        }
 
-      // Build this multipart upload part info.
-      OzoneManagerProtocolProtos.PartKeyInfo.Builder partKeyInfo =
-          OzoneManagerProtocolProtos.PartKeyInfo.newBuilder();
-      partKeyInfo.setPartName(partName);
-      partKeyInfo.setPartNumber(partNumber);
-      partKeyInfo.setPartKeyInfo(omKeyInfo.getProtobuf(
-          getOmRequest().getVersion()));
-
-      // Add this part information in to multipartKeyInfo.
-      multipartKeyInfo.addPartKeyInfo(partKeyInfo.build());
+        // Build this multipart upload part info and add it inline.
+        OzoneManagerProtocolProtos.PartKeyInfo.Builder partKeyInfo =
+            OzoneManagerProtocolProtos.PartKeyInfo.newBuilder();
+        partKeyInfo.setPartName(partName);
+        partKeyInfo.setPartNumber(partNumber);
+        partKeyInfo.setPartKeyInfo(omKeyInfo.getProtobuf(
+            getOmRequest().getVersion()));
+        multipartKeyInfo.addPartKeyInfo(partKeyInfo.build());
+      } else {
+        // Read the previous part cache-aware so an unflushed re-commit of the
+        // same part number within this double-buffer batch is visible.
+        partsTableKey = OmMultipartPartKey.of(uploadID, partNumber);
+        OmMultipartPartInfo oldPart =
+            omMetadataManager.getMultipartPartsTable().get(partsTableKey);
+        if (oldPart != null) {
+          oldCommittedPart = oldPart.toOmKeyInfo(volumeName, bucketName,
+              keyName, multipartKeyInfo.getReplicationConfig());
+        }
+        // A split-table part must carry an eTag and block locations.
+        // OmMultipartPartInfo.from() would otherwise throw an unchecked
+        // exception, which in this apply path would terminate the OM; fail the
+        // request with a client error instead.
+        String partETag = omKeyInfo.getMetadata().get(OzoneConsts.ETAG);
+        if (partETag == null || partETag.isEmpty()
+            || omKeyInfo.getKeyLocationVersions() == null
+            || omKeyInfo.getKeyLocationVersions().isEmpty()) {
+          throw new OMException("Multipart part " + partNumber + " is missing "
+              + "an eTag or block locations required by the split parts table.",
+              OMException.ResultCodes.INVALID_REQUEST);
+        }
+        newPartInfo = OmMultipartPartInfo.from(partName, partNumber, omKeyInfo);
+      }
 
       // Set the UpdateID to current transactionLogIndex
       multipartKeyInfo = multipartKeyInfo.toBuilder()
@@ -223,14 +259,19 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       // S3MultipartUploadCommitPartResponse before being added to
       // DeletedKeyTable.
 
-      // Add to cache.
-
-      // Delete from open key table and add it to multipart info table.
-      // No need to add cache entries to delete table, as no
-      // read/write requests that info for validation.
+      // Add to cache. Delete from open key table and add it to multipart info
+      // table; for schemaVersion 1 also stage the new part row. No need to add
+      // cache entries to delete table, as no read/write requests use that info
+      // for validation.
       omMetadataManager.getMultipartInfoTable().addCacheEntry(
           new CacheKey<>(multipartKey),
           CacheValue.get(trxnLogIndex, multipartKeyInfo));
+
+      if (newPartInfo != null) {
+        omMetadataManager.getMultipartPartsTable().addCacheEntry(
+            new CacheKey<>(partsTableKey),
+            CacheValue.get(trxnLogIndex, newPartInfo));
+      }
 
       omMetadataManager.getOpenKeyTable(getBucketLayout()).addCacheEntry(
           new CacheKey<>(openKey),
@@ -244,16 +285,14 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       Map<String, RepeatedOmKeyInfo> keyVersionsToDeleteMap = null;
 
       long correctedSpace = omKeyInfo.getReplicatedSize();
-      if (null != oldPartKeyInfo) {
-        OmKeyInfo partKeyToBeDeleted =
-            OmKeyInfo.getFromProtobuf(oldPartKeyInfo.getPartKeyInfo());
-        correctedSpace -= partKeyToBeDeleted.getReplicatedSize();
-        RepeatedOmKeyInfo oldVerKeyInfo = getOldVersionsToCleanUp(partKeyToBeDeleted, omBucketInfo.getObjectID(),
+      if (null != oldCommittedPart) {
+        correctedSpace -= oldCommittedPart.getReplicatedSize();
+        RepeatedOmKeyInfo oldVerKeyInfo = getOldVersionsToCleanUp(oldCommittedPart, omBucketInfo.getObjectID(),
             trxnLogIndex);
         // Unlike normal key commit, we can reuse the objectID for MPU part key because MPU part key
         // always use a new object ID regardless whether there is an existing key.
         String delKeyName = omMetadataManager.getOzoneDeletePathKey(
-            partKeyToBeDeleted.getObjectID(), multipartKey);
+            oldCommittedPart.getObjectID(), multipartKey);
 
         if (!oldVerKeyInfo.getOmKeyInfoList().isEmpty()) {
           keyVersionsToDeleteMap = new HashMap<>();
@@ -279,7 +318,8 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       omResponse.setCommitMultiPartUploadResponse(commitResponseBuilder);
       omClientResponse =
           getOmClientResponse(ozoneManager, keyVersionsToDeleteMap, openKey,
-              omKeyInfo, multipartKey, multipartKeyInfo, omResponse.build(),
+              omKeyInfo, multipartKey, multipartKeyInfo, partsTableKey,
+              newPartInfo, omResponse.build(),
               omBucketInfo.copyObject(), bucketId);
 
       result = Result.SUCCESS;
@@ -288,7 +328,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       exception = ex;
       omClientResponse =
           getOmClientResponse(ozoneManager, null, openKey,
-              omKeyInfo, multipartKey, multipartKeyInfo,
+              omKeyInfo, multipartKey, multipartKeyInfo, null, null,
               createErrorOMResponse(omResponse, exception), copyBucketInfo, bucketId);
     } finally {
       if (acquiredLock) {
@@ -317,11 +357,12 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
   protected S3MultipartUploadCommitPartResponse getOmClientResponse(
       OzoneManager ozoneManager, Map<String, RepeatedOmKeyInfo> keyToDeleteMap,
       String openKey, OmKeyInfo omKeyInfo, String multipartKey,
-      OmMultipartKeyInfo multipartKeyInfo, OMResponse build,
+      OmMultipartKeyInfo multipartKeyInfo, OmMultipartPartKey partsTableKey,
+      OmMultipartPartInfo newPartInfo, OMResponse build,
       OmBucketInfo omBucketInfo, long bucketId) {
 
     return new S3MultipartUploadCommitPartResponse(build, multipartKey, openKey,
-        multipartKeyInfo, keyToDeleteMap, omKeyInfo,
+        multipartKeyInfo, keyToDeleteMap, omKeyInfo, partsTableKey, newPartInfo,
         omBucketInfo, bucketId, getBucketLayout());
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -235,16 +235,24 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
           oldCommittedPart = oldPart.toOmKeyInfo(volumeName, bucketName,
               keyName, multipartKeyInfo.getReplicationConfig());
         }
-        // A split-table part must carry an eTag and block locations.
-        // OmMultipartPartInfo.from() would otherwise throw an unchecked
-        // exception, which in this apply path would terminate the OM; fail the
-        // request with a client error instead.
-        String partETag = omKeyInfo.getMetadata().get(OzoneConsts.ETAG);
-        if (partETag == null || partETag.isEmpty()
-            || omKeyInfo.getKeyLocationVersions() == null
+        // A split-table part must carry block locations: OmMultipartPartInfo
+        // requires them (and Complete reads the first location group), so reject
+        // a location-less commit with a client error rather than let from() throw
+        // an unchecked exception that would terminate the OM apply path.
+        //
+        // TODO(HDDS-14661 follow-up): the part eTag is intentionally NOT required
+        // here. schemaVersion 1 tolerates eTag-less parts to mirror the legacy
+        // schemaVersion 0 (inline) path, so the native Ozone client MPU path
+        // (OzoneBucket.createMultipartKey + write + close, which never sets an
+        // eTag) commits at schemaVersion 1. The S3 gateway always sets an eTag,
+        // so S3 clients are unaffected. Harden later (HDDS-9680-style): enforce
+        // or server-side auto-compute the part eTag (md5 of content) so the
+        // Complete final-key hash is content-derived for every part instead of
+        // falling back to the part name for eTag-less parts.
+        if (omKeyInfo.getKeyLocationVersions() == null
             || omKeyInfo.getKeyLocationVersions().isEmpty()) {
           throw new OMException("Multipart part " + partNumber + " is missing "
-              + "an eTag or block locations required by the split parts table.",
+              + "block locations required by the split parts table.",
               OMException.ResultCodes.INVALID_REQUEST);
         }
         newPartInfo = OmMultipartPartInfo.from(partName, partNumber, omKeyInfo);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequestWithFSO.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmFSOFile;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.response.s3.multipart.S3MultipartUploadCommitPartResponse;
@@ -71,11 +73,12 @@ public class S3MultipartUploadCommitPartRequestWithFSO
       OzoneManager ozoneManager,
       Map<String, RepeatedOmKeyInfo> keyToDeleteMap, String openKey,
       OmKeyInfo omKeyInfo, String multipartKey,
-      OmMultipartKeyInfo multipartKeyInfo,
+      OmMultipartKeyInfo multipartKeyInfo, OmMultipartPartKey partsTableKey,
+      OmMultipartPartInfo newPartInfo,
       OzoneManagerProtocolProtos.OMResponse build, OmBucketInfo omBucketInfo, long bucketId) {
 
     return new S3MultipartUploadCommitPartResponseWithFSO(build, multipartKey,
-        openKey, multipartKeyInfo, keyToDeleteMap, omKeyInfo,
-        omBucketInfo, bucketId, getBucketLayout());
+        openKey, multipartKeyInfo, keyToDeleteMap, omKeyInfo, partsTableKey,
+        newPartInfo, omBucketInfo, bucketId, getBucketLayout());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponse.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.response.s3.multipart;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_INFO_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_PARTS_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_KEY_TABLE;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.NO_SUCH_MULTIPART_UPLOAD_ERROR;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
@@ -36,6 +37,8 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.response.key.OmKeyResponse;
@@ -45,7 +48,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
  * Response for S3MultipartUploadCommitPart request.
  */
 @CleanupTableInfo(cleanupTables = {OPEN_KEY_TABLE, DELETED_TABLE,
-    MULTIPART_INFO_TABLE, BUCKET_TABLE})
+    MULTIPART_INFO_TABLE, MULTIPART_PARTS_TABLE, BUCKET_TABLE})
 public class S3MultipartUploadCommitPartResponse extends OmKeyResponse {
 
   private final String multipartKey;
@@ -53,6 +56,8 @@ public class S3MultipartUploadCommitPartResponse extends OmKeyResponse {
   private final OmMultipartKeyInfo omMultipartKeyInfo;
   private final Map<String, RepeatedOmKeyInfo> keyToDeleteMap;
   private final OmKeyInfo openPartKeyInfoToBeDeleted;
+  private final OmMultipartPartKey partsTableKey;
+  private final OmMultipartPartInfo newPartInfo;
   private final OmBucketInfo omBucketInfo;
   private final long bucketId;
 
@@ -68,6 +73,8 @@ public class S3MultipartUploadCommitPartResponse extends OmKeyResponse {
       @Nullable OmMultipartKeyInfo omMultipartKeyInfo,
       @Nullable Map<String, RepeatedOmKeyInfo> keyToDeleteMap,
       @Nullable OmKeyInfo openPartKeyInfoToBeDeleted,
+      @Nullable OmMultipartPartKey partsTableKey,
+      @Nullable OmMultipartPartInfo newPartInfo,
       @Nonnull OmBucketInfo omBucketInfo,
       long bucketId,
       @Nonnull BucketLayout bucketLayout) {
@@ -77,6 +84,8 @@ public class S3MultipartUploadCommitPartResponse extends OmKeyResponse {
     this.omMultipartKeyInfo = omMultipartKeyInfo;
     this.keyToDeleteMap = keyToDeleteMap;
     this.openPartKeyInfoToBeDeleted = openPartKeyInfoToBeDeleted;
+    this.partsTableKey = partsTableKey;
+    this.newPartInfo = newPartInfo;
     this.omBucketInfo = omBucketInfo;
     this.bucketId = bucketId;
   }
@@ -118,6 +127,13 @@ public class S3MultipartUploadCommitPartResponse extends OmKeyResponse {
 
     omMetadataManager.getMultipartInfoTable().putWithBatch(batchOperation,
         multipartKey, omMultipartKeyInfo);
+
+    // For schemaVersion 1 the committed part lives in the split parts table
+    // rather than inline in the multipart info row.
+    if (newPartInfo != null) {
+      omMetadataManager.getMultipartPartsTable().putWithBatch(batchOperation,
+          partsTableKey, newPartInfo);
+    }
 
     //  This information has been added to multipartKeyInfo. So, we can
     //  safely delete part key info from open key table.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCommitPartResponseWithFSO.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.response.s3.multipart;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_INFO_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_PARTS_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_FILE_TABLE;
 
 import jakarta.annotation.Nonnull;
@@ -29,6 +30,8 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -37,7 +40,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
  * Response for S3MultipartUploadCommitPartWithFSO request.
  */
 @CleanupTableInfo(cleanupTables = {OPEN_FILE_TABLE, DELETED_TABLE,
-    MULTIPART_INFO_TABLE, BUCKET_TABLE})
+    MULTIPART_INFO_TABLE, MULTIPART_PARTS_TABLE, BUCKET_TABLE})
 public class S3MultipartUploadCommitPartResponseWithFSO
         extends S3MultipartUploadCommitPartResponse {
 
@@ -53,10 +56,12 @@ public class S3MultipartUploadCommitPartResponseWithFSO
       @Nullable OmMultipartKeyInfo omMultipartKeyInfo,
       @Nullable Map<String, RepeatedOmKeyInfo> keyToDeleteMap,
       @Nullable OmKeyInfo openPartKeyInfoToBeDeleted,
+      @Nullable OmMultipartPartKey partsTableKey,
+      @Nullable OmMultipartPartInfo newPartInfo,
       @Nonnull OmBucketInfo omBucketInfo, long bucketId, @Nonnull BucketLayout bucketLayout) {
 
     super(omResponse, multipartKey, openKey, omMultipartKeyInfo,
-            keyToDeleteMap, openPartKeyInfoToBeDeleted,
-            omBucketInfo, bucketId, bucketLayout);
+            keyToDeleteMap, openPartKeyInfoToBeDeleted, partsTableKey,
+            newPartInfo, omBucketInfo, bucketId, bucketLayout);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
@@ -77,7 +77,6 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartUpload;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadList;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadListParts;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
-import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -160,57 +159,36 @@ class TestKeyManagerUnit extends OzoneTestBase {
 
   @Test
   public void listMultipartUploadPartsWithoutEtagField() throws IOException {
-    // For backward compatibility reasons
+    // Backward compatibility: parts committed before HDDS-9680 carry no eTag
+    // metadata. Both schemaVersion 0 and 1 tolerate eTag-less parts (the S3
+    // gateway always sets one; the native client does not). Seed a
+    // schemaVersion 0 upload with eTag-less inline parts directly and verify
+    // listParts still surfaces every part via the eTag-absent fallback.
     final String volume = volumeName();
     final String bucket = "bucketForEtag";
     final String key = "dir/key1";
     createBucket(metadataManager, volume, bucket);
-    OmMultipartInfo omMultipartInfo =
-        initMultipartUpload(writeClient, volume, bucket, key);
 
-
-    // Commit some MPU parts without eTag field
+    String uploadID = UUID.randomUUID().toString();
+    OmMultipartKeyInfo.Builder mpuBuilder = new OmMultipartKeyInfo.Builder()
+        .setUploadID(uploadID)
+        .setCreationTime(Time.now())
+        .setReplicationConfig(
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
     for (int i = 1; i <= 5; i++) {
-      OmKeyArgs partKeyArgs =
-          new OmKeyArgs.Builder()
-              .setVolumeName(volume)
-              .setBucketName(bucket)
-              .setKeyName(key)
-              .setIsMultipartKey(true)
-              .setMultipartUploadID(omMultipartInfo.getUploadID())
-              .setMultipartUploadPartNumber(i)
-              .setAcls(Collections.emptyList())
-              .setReplicationConfig(
-                  RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
-              .setOwnerName(UserGroupInformation.getCurrentUser().getShortUserName())
-              .build();
-
-      OpenKeySession openKey = writeClient.openKey(partKeyArgs);
-
-      OmKeyArgs commitPartKeyArgs =
-          new OmKeyArgs.Builder()
-              .setVolumeName(volume)
-              .setBucketName(bucket)
-              .setKeyName(key)
-              .setIsMultipartKey(true)
-              .setMultipartUploadID(omMultipartInfo.getUploadID())
-              .setMultipartUploadPartNumber(i)
-              .setAcls(Collections.emptyList())
-              .setReplicationConfig(
-                  RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
-              .setLocationInfoList(Collections.emptyList())
-              .build();
-
-      writeClient.commitMultipartUploadPart(commitPartKeyArgs, openKey.getId());
+      mpuBuilder.addPartKeyInfoList(i,
+          OMRequestTestUtils.createPartKeyInfo(volume, bucket, key, uploadID, i));
     }
-
+    // schemaVersion defaults to 0 (legacy inline layout).
+    metadataManager.getMultipartInfoTable().addCacheEntry(
+        new CacheKey<>(metadataManager.getMultipartKey(volume, bucket, key,
+            uploadID)),
+        CacheValue.get(RandomUtils.secure().randomInt(), mpuBuilder.build()));
 
     OmMultipartUploadListParts omMultipartUploadListParts = keyManager
-        .listParts(volume, bucket, key, omMultipartInfo.getUploadID(),
-            0, 10);
+        .listParts(volume, bucket, key, uploadID, 0, 10);
     assertEquals(5,
         omMultipartUploadListParts.getPartInfoList().size());
-
   }
 
   private String volumeName() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -38,10 +39,12 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.s3.multipart.S3MultipartUploadCommitPartResponse;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyLocation;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
@@ -257,6 +260,57 @@ public class TestS3MultipartUploadCommitPartRequest
     assertFalse(omMetadataManager.getDeletedTable()
             .getRangeKVs(null, 100, "").isEmpty(),
         "orphaned part should be moved to the deleted table for GC");
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheV1WritesPartToPartsTable()
+      throws Exception {
+    // Post-finalization: initiate creates a schemaVersion 1 upload, so commit
+    // must persist the part in the split parts table and leave the multipart
+    // info row's inline part list empty.
+    when(ozoneManager.getVersionManager().getMetadataLayoutVersion())
+        .thenReturn(OMLayoutFeature.MPU_PARTS_TABLE_SPLIT.layoutVersion());
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = getKeyName();
+
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, getBucketLayout());
+    createParentPath(volumeName, bucketName);
+
+    OMRequest initiateMPURequest =
+        doPreExecuteInitiateMPU(volumeName, bucketName, keyName);
+    OMClientResponse initiateResponse =
+        getS3InitiateMultipartUploadReq(initiateMPURequest)
+            .validateAndUpdateCache(ozoneManager, 1L);
+    String multipartUploadID = initiateResponse.getOMResponse()
+        .getInitiateMultiPartUploadResponse().getMultipartUploadID();
+
+    long clientID = Time.now();
+    OMRequest commitMultipartRequest = doPreExecuteCommitMPU(volumeName,
+        bucketName, keyName, clientID, multipartUploadID, 1);
+    S3MultipartUploadCommitPartRequest s3MultipartUploadCommitPartRequest =
+        getS3MultipartUploadCommitReq(commitMultipartRequest);
+    addKeyToOpenKeyTable(volumeName, bucketName, keyName, clientID);
+
+    OMClientResponse omClientResponse =
+        s3MultipartUploadCommitPartRequest.validateAndUpdateCache(ozoneManager,
+            2L);
+    assertSame(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+
+    String multipartKey = omMetadataManager.getMultipartKey(volumeName,
+        bucketName, keyName, multipartUploadID);
+    OmMultipartKeyInfo multipartKeyInfo =
+        omMetadataManager.getMultipartInfoTable().get(multipartKey);
+    assertNotNull(multipartKeyInfo);
+    assertEquals(1, multipartKeyInfo.getSchemaVersion());
+    // Parts are not inlined for schemaVersion 1.
+    assertEquals(0, multipartKeyInfo.getPartKeyInfoMap().size());
+    // The committed part lives in the split parts table.
+    assertNotNull(omMetadataManager.getMultipartPartsTable()
+        .get(OmMultipartPartKey.of(multipartUploadID, 1)));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
@@ -314,6 +314,79 @@ public class TestS3MultipartUploadCommitPartRequest
   }
 
   @Test
+  public void testValidateAndUpdateCacheV1OnOverwriteReclaimsOldPartBlocks()
+      throws Exception {
+    // Post-finalization v1 upload: re-committing the same part number must
+    // reclaim the previously-committed part's blocks (read from the split
+    // parts table and reconstructed via toOmKeyInfo) and store the new part,
+    // exactly as the v0 inline path reclaims the overwritten inline part.
+    when(ozoneManager.getVersionManager().getMetadataLayoutVersion())
+        .thenReturn(OMLayoutFeature.MPU_PARTS_TABLE_SPLIT.layoutVersion());
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = getKeyName();
+
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, getBucketLayout());
+    createParentPath(volumeName, bucketName);
+
+    OMRequest initiateMPURequest =
+        doPreExecuteInitiateMPU(volumeName, bucketName, keyName);
+    String multipartUploadID = getS3InitiateMultipartUploadReq(initiateMPURequest)
+        .validateAndUpdateCache(ozoneManager, 1L).getOMResponse()
+        .getInitiateMultiPartUploadResponse().getMultipartUploadID();
+
+    // First commit of part 1 (2 blocks).
+    long clientID = Time.now();
+    List<KeyLocation> originalKeyLocationList = getKeyLocation(5).subList(0, 2);
+    List<OmKeyLocationInfo> originalKeyLocationInfos = originalKeyLocationList
+        .stream().map(OmKeyLocationInfo::getFromProtobuf)
+        .collect(Collectors.toList());
+    addKeyToOpenKeyTable(volumeName, bucketName, keyName, clientID,
+        originalKeyLocationInfos);
+    OMRequest commitMultipartRequest = doPreExecuteCommitMPU(volumeName,
+        bucketName, keyName, clientID, multipartUploadID, 1,
+        originalKeyLocationList);
+    getS3MultipartUploadCommitReq(commitMultipartRequest)
+        .validateAndUpdateCache(ozoneManager, 2L);
+
+    OmMultipartPartKey partKey = OmMultipartPartKey.of(multipartUploadID, 1);
+    assertNotNull(omMetadataManager.getMultipartPartsTable().get(partKey));
+
+    // Re-commit part 1 (overwrite, 3 different blocks).
+    clientID = Time.now();
+    List<KeyLocation> overwriteKeyLocationList = getKeyLocation(5).subList(2, 5);
+    List<OmKeyLocationInfo> overwriteKeyLocationInfos = overwriteKeyLocationList
+        .stream().map(OmKeyLocationInfo::getFromProtobuf)
+        .collect(Collectors.toList());
+    addKeyToOpenKeyTable(volumeName, bucketName, keyName, clientID,
+        overwriteKeyLocationInfos);
+    OMRequest overwriteOMRequest = doPreExecuteCommitMPU(volumeName,
+        bucketName, keyName, clientID, multipartUploadID, 1,
+        overwriteKeyLocationList);
+    OMClientResponse overwriteResponse =
+        getS3MultipartUploadCommitReq(overwriteOMRequest)
+            .validateAndUpdateCache(ozoneManager, 3L);
+    assertSame(OzoneManagerProtocolProtos.Status.OK,
+        overwriteResponse.getOMResponse().getStatus());
+
+    // The part row still exists (overwritten with the new part).
+    assertNotNull(omMetadataManager.getMultipartPartsTable().get(partKey));
+
+    // The previously-committed part's blocks must be queued for deletion,
+    // matching the v0 inline behaviour (the 2 original blocks). This proves
+    // the synthesized OmKeyInfo fed the old part's blocks to the GC path.
+    Map<String, RepeatedOmKeyInfo> toDeleteKeyList =
+        ((S3MultipartUploadCommitPartResponse) overwriteResponse)
+            .getKeyToDelete();
+    assertEquals(1, toDeleteKeyList.size());
+    assertEquals(originalKeyLocationList.size(), toDeleteKeyList.values()
+        .stream().findFirst().get().cloneOmKeyInfoList().get(0)
+        .getKeyLocationVersions().get(0).getLocationList().size());
+  }
+
+  @Test
   public void testValidateAndUpdateCacheKeyNotFound() throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -291,8 +291,8 @@ public class TestS3MultipartResponse {
 
     return new S3MultipartUploadCommitPartResponseWithFSO(omResponse,
         multipartKey, openKey, multipartKeyInfo, keyToDeleteMap,
-        openPartKeyInfoToBeDeleted, omBucketInfo, omBucketInfo.getObjectID(),
-        getBucketLayout());
+        openPartKeyInfoToBeDeleted, null, null, omBucketInfo,
+        omBucketInfo.getObjectID(), getBucketLayout());
   }
 
   @SuppressWarnings("checkstyle:ParameterNumber")


### PR DESCRIPTION
## Summary

**Part 2 of the stacked series** completing the MPU GC optimization (epic HDDS-10611). It stacks on **part 1** (spacemonkd/ozone#122, branch `HDDS-14661-1-foundation`) — this PR's base is that branch, so the diff here is only the CommitPart write side. Final target is `HDDS-14665` (apache/ozone#10062).

This part makes CommitPart actually use the split parts table for `schemaVersion = 1` uploads — the core of the GC-pressure win.

## What it does

For a `schemaVersion = 1` upload, `S3MultipartUploadCommitPartRequest` now:
- stores each committed part as an `OmMultipartPartInfo` row in `multipartPartsTable` keyed by `OmMultipartPartKey(uploadId, partNumber)`, instead of inlining it in `MultipartKeyInfo` — so the info row stays small no matter how many parts a huge upload has;
- on re-commit of the same part number, reads the previous part **cache-aware** (`getMultipartPartsTable().get(...)`, so an unflushed prior commit in the same double-buffer batch is visible) and reclaims its blocks through the existing quota / old-version cleanup path;
- reconstructs the old part as an `OmKeyInfo` via the new `OmMultipartPartInfo#toOmKeyInfo`, joining the replication config from the parent upload (the part row carries none), so the deleted-table entries and quota delta match the v0 inline path exactly.

`schemaVersion = 0` uploads keep the inline path byte-for-byte. Both the object-store and FSO responses persist the part row and declare `MULTIPART_PARTS_TABLE` in `@CleanupTableInfo`.

A split-table part requires an eTag and block locations. The request rejects a part lacking them with a client error (`INVALID_REQUEST`) rather than letting `OmMultipartPartInfo.from()` throw an unchecked exception in the apply path, which would terminate the OM.

## Testing

`mvn -pl hadoop-ozone/ozone-manager test` for the CommitPart request/response classes, object-store and FSO:
- **v0 regression: 39/0** — existing behaviour unchanged.
- **v1 write: 26/0** — a fresh part is stored in the split table with the info row's inline list empty.
- **v1 overwrite: 26/0** — re-committing a part queues exactly the previous part's blocks for deletion (the same `getKeyToDelete()` assertion the v0 inline overwrite test uses), proving block-GC and quota match v0.

## Next (stacked on this branch)

Complete v1 (cache-aware merge scan) → Abort + expired-abort v1 cleanup → listParts v1 → Recon (HDDS-14666).
