### PR TITLE
HDDS-14661. Complete MPU parts-table split (3/N): complete from the parts table

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartPartInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartPartInfo.java
@@ -335,7 +335,7 @@ public final class OmMultipartPartInfo {
    */
   public OmKeyInfo toOmKeyInfo(String volumeName, String bucketName,
       String keyName, ReplicationConfig replicationConfig) {
-    return new OmKeyInfo.Builder()
+    OmKeyInfo.Builder builder = new OmKeyInfo.Builder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
@@ -347,7 +347,14 @@ public final class OmMultipartPartInfo {
         .setObjectID(objectID)
         .setUpdateID(updateID)
         .setFileEncryptionInfo(encInfo)
-        .build();
+        .setFileChecksum(fileChecksum);
+    // Surface the eTag in metadata so Complete's per-part validation and the
+    // final-key hash -- both of which read ETAG from the part's OmKeyInfo
+    // metadata -- behave identically to the inline (schemaVersion 0) path.
+    if (eTag != null) {
+      builder.addMetadata(OzoneConsts.ETAG, eTag);
+    }
+    return builder.build();
   }
 
   private KeyLocationList getKeyLocationInfosAsProto() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/MultipartPartScanUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/MultipartPartScanUtil.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.s3.multipart;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
+import org.apache.hadoop.hdds.utils.db.Table.KeyValueIterator;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
+
+/**
+ * Reads the parts of a schemaVersion 1 multipart upload from the split parts
+ * table.
+ *
+ * <p>The scan is <em>cache-aware</em>: it merges the in-memory table cache over
+ * the persisted RocksDB rows so that parts written by an earlier CommitPart in
+ * the same (not-yet-flushed) double-buffer batch are visible to a later
+ * Complete/Abort applied in that same batch. A raw RocksDB iterator would miss
+ * them, because the OM apply path does not flush between transactions. The
+ * cache wins over the persisted view, and a cache entry whose value is
+ * {@code null} (a delete) tombstones the corresponding row.</p>
+ */
+public final class MultipartPartScanUtil {
+
+  private MultipartPartScanUtil() {
+  }
+
+  /**
+   * Returns all parts of {@code uploadId}, ordered ascending by part number.
+   *
+   * @param omMetadataManager the OM metadata manager
+   * @param uploadId the multipart upload id
+   * @return part number -&gt; part info, sorted by part number
+   */
+  public static SortedMap<Integer, OmMultipartPartInfo> scanParts(
+      OMMetadataManager omMetadataManager, String uploadId)
+      throws IOException {
+    Table<OmMultipartPartKey, OmMultipartPartInfo> partsTable =
+        omMetadataManager.getMultipartPartsTable();
+
+    SortedMap<Integer, OmMultipartPartInfo> parts = new TreeMap<>();
+
+    // Persisted base: every row under the uploadId prefix, in part-number
+    // order (the key encoding sorts by part number).
+    try (KeyValueIterator<OmMultipartPartKey, OmMultipartPartInfo> iterator =
+        partsTable.iterator(OmMultipartPartKey.prefix(uploadId))) {
+      while (iterator.hasNext()) {
+        KeyValue<OmMultipartPartKey, OmMultipartPartInfo> kv = iterator.next();
+        if (kv.getKey().hasPartNumber()) {
+          parts.put(kv.getKey().getPartNumber(), kv.getValue());
+        }
+      }
+    }
+
+    // Overlay the cache (uncommitted writes win; a null value tombstones).
+    Iterator<Map.Entry<CacheKey<OmMultipartPartKey>,
+        CacheValue<OmMultipartPartInfo>>> cacheIterator =
+        partsTable.cacheIterator();
+    while (cacheIterator.hasNext()) {
+      Map.Entry<CacheKey<OmMultipartPartKey>,
+          CacheValue<OmMultipartPartInfo>> entry = cacheIterator.next();
+      OmMultipartPartKey key = entry.getKey().getCacheKey();
+      if (!uploadId.equals(key.getUploadId()) || !key.hasPartNumber()) {
+        continue;
+      }
+      OmMultipartPartInfo value = entry.getValue().getCacheValue();
+      if (value == null) {
+        parts.remove(key.getPartNumber());
+      } else {
+        parts.put(key.getPartNumber(), value);
+      }
+    }
+
+    return parts;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -29,6 +29,8 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -51,6 +53,8 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
@@ -286,8 +290,27 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       validateIfMatchETag(keyArgs, existingKeyInfo);
 
       if (!partsList.isEmpty()) {
-        final OmMultipartKeyInfo.PartKeyInfoMap partKeyInfoMap
-            = multipartKeyInfo.getPartKeyInfoMap();
+        final OmMultipartKeyInfo.PartKeyInfoMap partKeyInfoMap;
+        final List<OmMultipartPartKey> partsTableKeysToDelete =
+            new ArrayList<>();
+        if (multipartKeyInfo.getSchemaVersion() == 0) {
+          partKeyInfoMap = multipartKeyInfo.getPartKeyInfoMap();
+        } else {
+          // schemaVersion 1: parts live in the split parts table. Read them
+          // cache-aware and adapt to the inline PartKeyInfoMap shape so the
+          // validation and assembly below are identical to the legacy path.
+          SortedMap<Integer, OmMultipartPartInfo> tableParts =
+              MultipartPartScanUtil.scanParts(omMetadataManager, uploadID);
+          partKeyInfoMap = buildPartKeyInfoMap(tableParts, volumeName,
+              bucketName, keyName, multipartKeyInfo.getReplicationConfig());
+          // Reclaim every scanned part row -- used parts (whose blocks now live
+          // in the assembled key) and discarded parts alike. Discarded parts'
+          // blocks are separately tombstoned by the unused-parts loop below.
+          for (Integer partNumber : tableParts.keySet()) {
+            partsTableKeysToDelete.add(
+                OmMultipartPartKey.of(uploadID, partNumber));
+          }
+        }
         if (partKeyInfoMap.size() == 0) {
           LOG.error("Complete MultipartUpload failed for key {} , MPU Key has" +
                   " no parts in OM, parts given to upload are {}", ozoneKey,
@@ -357,6 +380,14 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         updateCache(omMetadataManager, dbBucketKey, omBucketInfo, dbOzoneKey,
             dbMultipartOpenKey, multipartKey, omKeyInfo, trxnLogIndex);
 
+        // schemaVersion 1: the split-table part rows are no longer needed once
+        // the key is assembled; tombstone them in cache (the response deletes
+        // them from the DB).
+        for (OmMultipartPartKey partKey : partsTableKeysToDelete) {
+          omMetadataManager.getMultipartPartsTable().addCacheEntry(
+              new CacheKey<>(partKey), CacheValue.get(trxnLogIndex));
+        }
+
         omResponse.setCompleteMultiPartUploadResponse(
             MultipartUploadCompleteResponse.newBuilder()
                 .setVolume(requestedVolume)
@@ -369,7 +400,8 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         omClientResponse =
             getOmClientResponse(multipartKey, omResponse, dbMultipartOpenKey,
                 omKeyInfo, allKeyInfoToRemove, omBucketInfo,
-                volumeId, bucketId, missingParentInfos, multipartKeyInfo);
+                volumeId, bucketId, missingParentInfos, multipartKeyInfo,
+                partsTableKeysToDelete);
 
         result = Result.SUCCESS;
       } else {
@@ -411,11 +443,35 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       OmKeyInfo omKeyInfo,  List<OmKeyInfo> allKeyInfoToRemove,
       OmBucketInfo omBucketInfo,
       long volumeId, long bucketId, List<OmDirectoryInfo> missingParentInfos,
-      OmMultipartKeyInfo multipartKeyInfo) {
+      OmMultipartKeyInfo multipartKeyInfo,
+      List<OmMultipartPartKey> partsTableKeysToDelete) {
 
     return new S3MultipartUploadCompleteResponse(omResponse.build(),
         multipartKey, dbMultipartOpenKey, omKeyInfo, allKeyInfoToRemove,
-        getBucketLayout(), omBucketInfo, bucketId);
+        getBucketLayout(), omBucketInfo, bucketId, partsTableKeysToDelete);
+  }
+
+  /**
+   * Adapts the split parts-table rows of a schemaVersion 1 upload into the
+   * inline {@link OmMultipartKeyInfo.PartKeyInfoMap} shape, so Complete's
+   * validation/assembly can consume them unchanged. The part's eTag is carried
+   * in the reconstructed key's metadata (see {@link OmMultipartPartInfo#toOmKeyInfo}).
+   */
+  private OmMultipartKeyInfo.PartKeyInfoMap buildPartKeyInfoMap(
+      SortedMap<Integer, OmMultipartPartInfo> tableParts, String volumeName,
+      String bucketName, String keyName, ReplicationConfig replicationConfig) {
+    SortedMap<Integer, PartKeyInfo> partKeyInfos = new TreeMap<>();
+    for (Map.Entry<Integer, OmMultipartPartInfo> entry
+        : tableParts.entrySet()) {
+      OmMultipartPartInfo part = entry.getValue();
+      partKeyInfos.put(entry.getKey(), PartKeyInfo.newBuilder()
+          .setPartNumber(part.getPartNumber())
+          .setPartName(part.getPartName())
+          .setPartKeyInfo(part.toOmKeyInfo(volumeName, bucketName, keyName,
+              replicationConfig).getProtobuf(getOmRequest().getVersion()))
+          .build());
+    }
+    return new OmMultipartKeyInfo.PartKeyInfoMap(partKeyInfos);
   }
 
   protected void checkDirectoryAlreadyExists(OzoneManager ozoneManager,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.s3.multipart.S3MultipartUploadCompleteResponse;
@@ -165,12 +166,13 @@ public class S3MultipartUploadCompleteRequestWithFSO
       String dbMultipartOpenKey, OmKeyInfo omKeyInfo,
       List<OmKeyInfo> allKeyInfoToRemove, OmBucketInfo omBucketInfo,
       long volumeId, long bucketId, List<OmDirectoryInfo> missingParentInfos,
-      OmMultipartKeyInfo multipartKeyInfo) {
+      OmMultipartKeyInfo multipartKeyInfo,
+      List<OmMultipartPartKey> partsTableKeysToDelete) {
 
     return new S3MultipartUploadCompleteResponseWithFSO(omResponse.build(),
         multipartKey, dbMultipartOpenKey, omKeyInfo, allKeyInfoToRemove,
         getBucketLayout(), omBucketInfo, volumeId, bucketId,
-        missingParentInfos, multipartKeyInfo);
+        missingParentInfos, multipartKeyInfo, partsTableKeysToDelete);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.KEY_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_INFO_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_PARTS_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_KEY_TABLE;
 
 import jakarta.annotation.Nonnull;
@@ -32,6 +33,7 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.response.key.OmKeyResponse;
@@ -46,7 +48,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
  * 3) Delete unused parts.
  */
 @CleanupTableInfo(cleanupTables = {OPEN_KEY_TABLE, KEY_TABLE, DELETED_TABLE,
-    MULTIPART_INFO_TABLE, BUCKET_TABLE})
+    MULTIPART_INFO_TABLE, MULTIPART_PARTS_TABLE, BUCKET_TABLE})
 public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
   private String multipartKey;
   private String multipartOpenKey;
@@ -54,6 +56,7 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
   private List<OmKeyInfo> allKeyInfoToRemove;
   private OmBucketInfo omBucketInfo;
   private long bucketId;
+  private List<OmMultipartPartKey> partsTableKeysToDelete;
 
   @SuppressWarnings("parameternumber")
   public S3MultipartUploadCompleteResponse(
@@ -64,7 +67,8 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
       @Nonnull List<OmKeyInfo> allKeyInfoToRemove,
       @Nonnull BucketLayout bucketLayout,
       OmBucketInfo omBucketInfo,
-      long bucketId) {
+      long bucketId,
+      @Nullable List<OmMultipartPartKey> partsTableKeysToDelete) {
     super(omResponse, bucketLayout);
     this.allKeyInfoToRemove = allKeyInfoToRemove;
     this.multipartKey = multipartKey;
@@ -72,6 +76,7 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
     this.omKeyInfo = omKeyInfo;
     this.omBucketInfo = omBucketInfo;
     this.bucketId = bucketId;
+    this.partsTableKeysToDelete = partsTableKeysToDelete;
   }
 
   /**
@@ -93,6 +98,14 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
         .deleteWithBatch(batchOperation, multipartOpenKey);
     omMetadataManager.getMultipartInfoTable().deleteWithBatch(batchOperation,
         multipartKey);
+
+    // schemaVersion 1: delete the upload's part rows from the split table.
+    if (partsTableKeysToDelete != null) {
+      for (OmMultipartPartKey partKey : partsTableKeysToDelete) {
+        omMetadataManager.getMultipartPartsTable()
+            .deleteWithBatch(batchOperation, partKey);
+      }
+    }
 
     // 2. Add key to KeyTable
     addToKeyTable(omMetadataManager, batchOperation);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DIRECTORY_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.FILE_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_INFO_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_PARTS_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_FILE_TABLE;
 
 import jakarta.annotation.Nonnull;
@@ -33,6 +34,7 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -46,7 +48,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
  * 3) Delete unused parts.
  */
 @CleanupTableInfo(cleanupTables = {OPEN_FILE_TABLE, FILE_TABLE, DELETED_TABLE,
-    MULTIPART_INFO_TABLE, DIRECTORY_TABLE})
+    MULTIPART_INFO_TABLE, MULTIPART_PARTS_TABLE, DIRECTORY_TABLE})
 public class S3MultipartUploadCompleteResponseWithFSO
         extends S3MultipartUploadCompleteResponse {
 
@@ -68,9 +70,11 @@ public class S3MultipartUploadCompleteResponseWithFSO
       OmBucketInfo omBucketInfo,
       @Nonnull long volumeId, @Nonnull long bucketId,
       List<OmDirectoryInfo> missingParentInfos,
-      OmMultipartKeyInfo multipartKeyInfo) {
+      OmMultipartKeyInfo multipartKeyInfo,
+      List<OmMultipartPartKey> partsTableKeysToDelete) {
     super(omResponse, multipartKey, multipartOpenKey, omKeyInfo,
-        allKeyInfoToRemove, bucketLayout, omBucketInfo, bucketId);
+        allKeyInfoToRemove, bucketLayout, omBucketInfo, bucketId,
+        partsTableKeysToDelete);
     this.volumeId = volumeId;
     this.bucketId = bucketId;
     this.missingParentInfos = missingParentInfos;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
@@ -20,9 +20,11 @@ package org.apache.hadoop.ozone.om.request.s3.multipart;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -37,9 +40,11 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Part;
@@ -118,6 +123,221 @@ public class TestS3MultipartUploadCompleteRequest
     // Count must consider unused parts on commit
     assertEquals(count,
         rangeKVs.get(0).getValue().getOmKeyInfoList().size());
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheV1CompletesFromPartsTable()
+      throws Exception {
+    // Post-finalization: parts live in the split table; Complete must assemble
+    // the final key from them (with the same ETag hash as the inline path) and
+    // delete the part rows.
+    when(ozoneManager.getVersionManager().getMetadataLayoutVersion())
+        .thenReturn(OMLayoutFeature.MPU_PARTS_TABLE_SPLIT.layoutVersion());
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = getKeyName();
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, getBucketLayout());
+
+    OMRequest initiateMPURequest =
+        doPreExecuteInitiateMPU(volumeName, bucketName, keyName);
+    String multipartUploadID =
+        getS3InitiateMultipartUploadReq(initiateMPURequest)
+            .validateAndUpdateCache(ozoneManager, 1L).getOMResponse()
+            .getInitiateMultiPartUploadResponse().getMultipartUploadID();
+
+    long clientID = Time.now();
+    OMRequest commitMultipartRequest = doPreExecuteCommitMPU(volumeName,
+        bucketName, keyName, clientID, multipartUploadID, 1);
+    S3MultipartUploadCommitPartRequest commitReq =
+        getS3MultipartUploadCommitReq(commitMultipartRequest);
+    addKeyToTable(volumeName, bucketName, keyName, clientID);
+    commitReq.validateAndUpdateCache(ozoneManager, 2L);
+
+    // The part is stored in the split table, not inline.
+    assertNotNull(omMetadataManager.getMultipartPartsTable()
+        .get(OmMultipartPartKey.of(multipartUploadID, 1)));
+
+    String eTag = commitReq.getOmRequest().getCommitMultiPartUploadRequest()
+        .getKeyArgs().getMetadataList().stream()
+        .filter(kv -> kv.getKey().equals(OzoneConsts.ETAG))
+        .findFirst().get().getValue();
+    List<Part> partList = new ArrayList<>();
+    partList.add(Part.newBuilder().setETag(eTag).setPartName(eTag)
+        .setPartNumber(1).build());
+
+    OMRequest completeMultipartRequest = doPreExecuteCompleteMPU(volumeName,
+        bucketName, keyName, multipartUploadID, partList);
+    S3MultipartUploadCompleteRequest completeReq =
+        getS3MultipartUploadCompleteReq(completeMultipartRequest);
+    OMClientResponse omClientResponse =
+        completeReq.validateAndUpdateCache(ozoneManager, 3L);
+
+    BatchOperation batchOperation =
+        omMetadataManager.getStore().initBatchOperation();
+    omClientResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+
+    String multipartKey = getMultipartKey(volumeName, bucketName, keyName,
+        multipartUploadID);
+    // Info row gone; final key assembled with the v0-equivalent ETag hash.
+    assertNull(omMetadataManager.getMultipartInfoTable().get(multipartKey));
+    OmKeyInfo finalKey = omMetadataManager
+        .getKeyTable(completeReq.getBucketLayout())
+        .get(getOzoneDBKey(volumeName, bucketName, keyName));
+    assertNotNull(finalKey);
+    assertEquals(DigestUtils.md5Hex(eTag) + "-1",
+        finalKey.getMetadata().get(OzoneConsts.ETAG));
+    // The split-table part row was deleted on completion.
+    assertNull(omMetadataManager.getMultipartPartsTable()
+        .get(OmMultipartPartKey.of(multipartUploadID, 1)));
+  }
+
+  /** Commits one part of a schemaVersion 1 upload and returns its eTag. */
+  private String commitV1Part(String volumeName, String bucketName,
+      String keyName, String multipartUploadID, int partNumber, long clientID,
+      long trxnLogIndex) throws Exception {
+    OMRequest commitMultipartRequest = doPreExecuteCommitMPU(volumeName,
+        bucketName, keyName, clientID, multipartUploadID, partNumber);
+    S3MultipartUploadCommitPartRequest commitReq =
+        getS3MultipartUploadCommitReq(commitMultipartRequest);
+    addKeyToTable(volumeName, bucketName, keyName, clientID);
+    commitReq.validateAndUpdateCache(ozoneManager, trxnLogIndex);
+    return commitReq.getOmRequest().getCommitMultiPartUploadRequest()
+        .getKeyArgs().getMetadataList().stream()
+        .filter(kv -> kv.getKey().equals(OzoneConsts.ETAG))
+        .findFirst().get().getValue();
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheV1MultiPartComplete() throws Exception {
+    // Three parts committed to the split table, completed in full: the final
+    // key's ETag hash must concatenate the part eTags in ascending part-number
+    // order (the v0 formula) and every part row must be deleted.
+    when(ozoneManager.getVersionManager().getMetadataLayoutVersion())
+        .thenReturn(OMLayoutFeature.MPU_PARTS_TABLE_SPLIT.layoutVersion());
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = getKeyName();
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, getBucketLayout());
+
+    OMRequest initiateMPURequest =
+        doPreExecuteInitiateMPU(volumeName, bucketName, keyName);
+    String multipartUploadID =
+        getS3InitiateMultipartUploadReq(initiateMPURequest)
+            .validateAndUpdateCache(ozoneManager, 1L).getOMResponse()
+            .getInitiateMultiPartUploadResponse().getMultipartUploadID();
+
+    String eTag1 = commitV1Part(volumeName, bucketName, keyName,
+        multipartUploadID, 1, Time.now(), 2L);
+    String eTag2 = commitV1Part(volumeName, bucketName, keyName,
+        multipartUploadID, 2, Time.now() + 1, 3L);
+    String eTag3 = commitV1Part(volumeName, bucketName, keyName,
+        multipartUploadID, 3, Time.now() + 2, 4L);
+
+    List<Part> partList = new ArrayList<>();
+    partList.add(Part.newBuilder().setETag(eTag1).setPartName(eTag1)
+        .setPartNumber(1).build());
+    partList.add(Part.newBuilder().setETag(eTag2).setPartName(eTag2)
+        .setPartNumber(2).build());
+    partList.add(Part.newBuilder().setETag(eTag3).setPartName(eTag3)
+        .setPartNumber(3).build());
+
+    OMRequest completeMultipartRequest = doPreExecuteCompleteMPU(volumeName,
+        bucketName, keyName, multipartUploadID, partList);
+    S3MultipartUploadCompleteRequest completeReq =
+        getS3MultipartUploadCompleteReq(completeMultipartRequest);
+    OMClientResponse omClientResponse =
+        completeReq.validateAndUpdateCache(ozoneManager, 5L);
+    BatchOperation batchOperation =
+        omMetadataManager.getStore().initBatchOperation();
+    omClientResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+
+    OmKeyInfo finalKey = omMetadataManager
+        .getKeyTable(completeReq.getBucketLayout())
+        .get(getOzoneDBKey(volumeName, bucketName, keyName));
+    assertNotNull(finalKey);
+    assertEquals(DigestUtils.md5Hex(eTag1 + eTag2 + eTag3) + "-3",
+        finalKey.getMetadata().get(OzoneConsts.ETAG));
+
+    // Every part row is reclaimed.
+    for (int partNumber = 1; partNumber <= 3; partNumber++) {
+      assertNull(omMetadataManager.getMultipartPartsTable()
+          .get(OmMultipartPartKey.of(multipartUploadID, partNumber)));
+    }
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheV1DiscardedPartReclaimed()
+      throws Exception {
+    // Parts 1, 2, 3 committed; Complete lists only [1, 3]. The discarded part 2
+    // must have its row deleted AND its key moved to the deleted table, and the
+    // listed parts' rows must also be deleted.
+    when(ozoneManager.getVersionManager().getMetadataLayoutVersion())
+        .thenReturn(OMLayoutFeature.MPU_PARTS_TABLE_SPLIT.layoutVersion());
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = getKeyName();
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, getBucketLayout());
+
+    OMRequest initiateMPURequest =
+        doPreExecuteInitiateMPU(volumeName, bucketName, keyName);
+    String multipartUploadID =
+        getS3InitiateMultipartUploadReq(initiateMPURequest)
+            .validateAndUpdateCache(ozoneManager, 1L).getOMResponse()
+            .getInitiateMultiPartUploadResponse().getMultipartUploadID();
+
+    String eTag1 = commitV1Part(volumeName, bucketName, keyName,
+        multipartUploadID, 1, Time.now(), 2L);
+    commitV1Part(volumeName, bucketName, keyName,
+        multipartUploadID, 2, Time.now() + 1, 3L);
+    String eTag3 = commitV1Part(volumeName, bucketName, keyName,
+        multipartUploadID, 3, Time.now() + 2, 4L);
+
+    List<Part> partList = new ArrayList<>();
+    partList.add(Part.newBuilder().setETag(eTag1).setPartName(eTag1)
+        .setPartNumber(1).build());
+    partList.add(Part.newBuilder().setETag(eTag3).setPartName(eTag3)
+        .setPartNumber(3).build());
+
+    OMRequest completeMultipartRequest = doPreExecuteCompleteMPU(volumeName,
+        bucketName, keyName, multipartUploadID, partList);
+    S3MultipartUploadCompleteRequest completeReq =
+        getS3MultipartUploadCompleteReq(completeMultipartRequest);
+    OMClientResponse omClientResponse =
+        completeReq.validateAndUpdateCache(ozoneManager, 5L);
+    BatchOperation batchOperation =
+        omMetadataManager.getStore().initBatchOperation();
+    omClientResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+
+    // All three part rows -- including the discarded part 2 -- are deleted.
+    for (int partNumber = 1; partNumber <= 3; partNumber++) {
+      assertNull(omMetadataManager.getMultipartPartsTable()
+          .get(OmMultipartPartKey.of(multipartUploadID, partNumber)));
+    }
+
+    // The discarded part's key was moved to the deleted table for block GC.
+    String multipartKey = getMultipartKey(volumeName, bucketName, keyName,
+        multipartUploadID);
+    assertFalse(omMetadataManager.getDeletedTable()
+            .getRangeKVs(null, 100, multipartKey).isEmpty(),
+        "discarded part should be moved to the deleted table");
   }
 
   private String checkValidateAndUpdateCacheSuccess(String volumeName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -327,7 +327,7 @@ public class TestS3MultipartResponse {
     return new S3MultipartUploadCompleteResponseWithFSO(omResponse,
         multipartKey, multipartOpenKey, omKeyInfo,  allKeyInfoToRemove,
         getBucketLayout(), omBucketInfo, volumeId, bucketId, null,
-        multipartKeyInfo);
+        multipartKeyInfo, null);
   }
 
   protected S3InitiateMultipartUploadResponse getS3InitiateMultipartUploadResp(


### PR DESCRIPTION
## Summary

**Part 3 of the stacked series** completing the MPU GC optimization (epic HDDS-10611). It stacks on **part 2** (kerneltime/ozone#13, branch `HDDS-14661-2-commitpart`) — this PR's base is that branch, so the diff here is only the Complete read/assemble/cleanup side. Final target is `HDDS-14665` (apache/ozone#10062).

## What it does

For a `schemaVersion = 1` upload, Complete reconstructs the part set from `multipartPartsTable` and assembles the final key from it, byte-identically to the legacy inline path:

- **New `MultipartPartScanUtil.scanParts(omMetadataManager, uploadId)`** — a **cache-aware** scan: RocksDB prefix iterator as the base, overlaid by the table cache (cache wins; a `null` cache value tombstones a row), returning the parts ordered by part number. This is required because the OM apply path does not flush between transactions, so a Complete in the same double-buffer batch as its CommitParts must see the not-yet-persisted part rows — a raw RocksDB iterator would miss them.
- The Complete request branches on `schemaVersion`: for v1 it adapts the scanned parts into the existing `OmMultipartKeyInfo.PartKeyInfoMap` shape (via `buildPartKeyInfoMap`) and feeds the **unchanged** validation/assembly/discarded-part-GC. So the assembled key's block list, dataSize, replication, and ETag hash are identical to v0. The part eTag is surfaced into the reconstructed key's metadata so per-part validation and the final-key hash read it exactly as the inline path does.
- Every scanned part row (used **and** discarded) is tombstoned in cache and deleted from the DB by the response, which declares `MULTIPART_PARTS_TABLE` in `@CleanupTableInfo`. Discarded parts' blocks are reclaimed by the existing unused-parts cleanup loop. Object-store and FSO.

## Testing

`mvn -pl hadoop-ozone/ozone-manager test` for the Complete + CommitPart classes, object-store and FSO:
- **v0 regression: 44/0.**
- **v1 single-part Complete** — final key's ETag hash byte-identical to v0; part row deleted.
- **v1 multi-part Complete** — final ETag is `md5(eTag1+eTag2+eTag3)+"-3"` (ascending part-number order); all rows deleted.
- **v1 discarded-part** — commit parts 1,2,3, complete with `[1,3]`: all three rows deleted and the discarded part moved to the deleted table for block GC.

This was additionally checked by an adversarial review across four lenses (assembly byte-equivalence, part-row/block lifecycle, edge cases, FSO/HA determinism), which found the apply-path logic correct by construction and flagged the multi-part/discarded test gap now closed here.

## Next (stacked on this branch)

Abort + expired-abort v1 cleanup (reuses `scanParts`; closes the parts-table quota/block leak on abort) → listParts v1 → Recon (HDDS-14666).
