### PR TITLE
HDDS-14661. Complete MPU parts-table split (4/N): reclaim parts on abort

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartAbortInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartAbortInfo.java
@@ -17,6 +17,8 @@
 
 package org.apache.hadoop.ozone.om.helpers;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -28,13 +30,24 @@ public final class OmMultipartAbortInfo {
   private final String multipartOpenKey;
   private final OmMultipartKeyInfo omMultipartKeyInfo;
   private final BucketLayout bucketLayout;
+  // For schemaVersion 1 uploads the parts live in the split parts table: the
+  // synthesized part keys to tombstone for block GC, and the parts-table rows
+  // to delete. Empty for schemaVersion 0 (parts inline in omMultipartKeyInfo).
+  private final List<OmKeyInfo> partsKeyInfoToDelete;
+  private final List<OmMultipartPartKey> partsTableKeysToDelete;
 
   private OmMultipartAbortInfo(String multipartKey, String multipartOpenKey,
-      OmMultipartKeyInfo omMultipartKeyInfo, BucketLayout bucketLayout) {
+      OmMultipartKeyInfo omMultipartKeyInfo, BucketLayout bucketLayout,
+      List<OmKeyInfo> partsKeyInfoToDelete,
+      List<OmMultipartPartKey> partsTableKeysToDelete) {
     this.multipartKey = multipartKey;
     this.multipartOpenKey = multipartOpenKey;
     this.omMultipartKeyInfo = omMultipartKeyInfo;
     this.bucketLayout = bucketLayout;
+    this.partsKeyInfoToDelete = partsKeyInfoToDelete == null
+        ? Collections.emptyList() : partsKeyInfoToDelete;
+    this.partsTableKeysToDelete = partsTableKeysToDelete == null
+        ? Collections.emptyList() : partsTableKeysToDelete;
   }
 
   public String getMultipartKey() {
@@ -53,6 +66,14 @@ public final class OmMultipartAbortInfo {
     return bucketLayout;
   }
 
+  public List<OmKeyInfo> getPartsKeyInfoToDelete() {
+    return partsKeyInfoToDelete;
+  }
+
+  public List<OmMultipartPartKey> getPartsTableKeysToDelete() {
+    return partsTableKeysToDelete;
+  }
+
   /**
    * Builder of OmMultipartAbortInfo.
    */
@@ -61,6 +82,8 @@ public final class OmMultipartAbortInfo {
     private String multipartOpenKey;
     private OmMultipartKeyInfo omMultipartKeyInfo;
     private BucketLayout bucketLayout;
+    private List<OmKeyInfo> partsKeyInfoToDelete;
+    private List<OmMultipartPartKey> partsTableKeysToDelete;
 
     public Builder setMultipartKey(String mpuKey) {
       this.multipartKey = mpuKey;
@@ -82,9 +105,20 @@ public final class OmMultipartAbortInfo {
       return this;
     }
 
+    public Builder setPartsKeyInfoToDelete(List<OmKeyInfo> parts) {
+      this.partsKeyInfoToDelete = parts;
+      return this;
+    }
+
+    public Builder setPartsTableKeysToDelete(List<OmMultipartPartKey> keys) {
+      this.partsTableKeysToDelete = keys;
+      return this;
+    }
+
     public OmMultipartAbortInfo build() {
       return new OmMultipartAbortInfo(multipartKey,
-          multipartOpenKey, omMultipartKeyInfo, bucketLayout);
+          multipartOpenKey, omMultipartKeyInfo, bucketLayout,
+          partsKeyInfoToDelete, partsTableKeysToDelete);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3ExpiredMultipartUploadsAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3ExpiredMultipartUploadsAbortRequest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -35,9 +36,13 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.execution.flowcontrol.ExecutionContext;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartAbortInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUpload;
+import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
 import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.ozone.om.request.util.OMMultipartUploadUtils;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -271,16 +276,18 @@ public class S3ExpiredMultipartUploadsAbortRequest extends OMKeyRequest {
           }
 
           // When abort uploaded key, we need to subtract the PartKey length
-          // from the volume usedBytes.
-          long quotaReleased = 0;
-          int keyFactor = omMultipartKeyInfo.getReplicationConfig()
-              .getRequiredNodes();
-          for (PartKeyInfo iterPartKeyInfo : omMultipartKeyInfo.
-              getPartKeyInfoMap()) {
-            quotaReleased +=
-                iterPartKeyInfo.getPartKeyInfo().getDataSize() * keyFactor;
-          }
+          // from the volume usedBytes. schemaVersion 0 keeps the parts inline;
+          // schemaVersion 1 reads them from the split parts table, synthesizes
+          // their key info for block GC, and tombstones the part rows.
+          List<OmKeyInfo> partsKeyInfoToDelete = new ArrayList<>();
+          List<OmMultipartPartKey> partsTableKeysToDelete = new ArrayList<>();
+          long quotaReleased = reclaimExpiredParts(omMetadataManager,
+              omMultipartKeyInfo, multipartUpload, trxnLogIndex,
+              partsKeyInfoToDelete, partsTableKeysToDelete);
           omBucketInfo.incrUsedBytes(-quotaReleased);
+          long numParts = omMultipartKeyInfo.getSchemaVersion() == 0
+              ? omMultipartKeyInfo.getPartKeyInfoMap().size()
+              : partsTableKeysToDelete.size();
 
           OmMultipartAbortInfo omMultipartAbortInfo =
               new OmMultipartAbortInfo.Builder()
@@ -288,6 +295,8 @@ public class S3ExpiredMultipartUploadsAbortRequest extends OMKeyRequest {
                   .setMultipartOpenKey(multipartOpenKey)
                   .setMultipartKeyInfo(omMultipartKeyInfo)
                   .setBucketLayout(omBucketInfo.getBucketLayout())
+                  .setPartsKeyInfoToDelete(partsKeyInfoToDelete)
+                  .setPartsTableKeysToDelete(partsTableKeysToDelete)
                   .build();
 
           abortedMultipartUploads.computeIfAbsent(omBucketInfo,
@@ -315,7 +324,6 @@ public class S3ExpiredMultipartUploadsAbortRequest extends OMKeyRequest {
               .addCacheEntry(new CacheKey<>(expiredMPUKeyName),
                   CacheValue.get(trxnLogIndex));
 
-          long numParts = omMultipartKeyInfo.getPartKeyInfoMap().size();
           ozoneManager.getMetrics().incNumExpiredMPUAborted();
           ozoneManager.getMetrics().incNumExpiredMPUPartsAborted(numParts);
           LOG.debug("Expired MPU {} aborted containing {} parts.",
@@ -332,5 +340,48 @@ public class S3ExpiredMultipartUploadsAbortRequest extends OMKeyRequest {
       }
     }
 
+  }
+
+  /**
+   * Subtract every part's size (scaled by replication) from the bucket
+   * usedBytes and collect the parts to reclaim for an expired upload.
+   * schemaVersion 0 keeps parts inline; schemaVersion 1 reads them from the
+   * split parts table, synthesizes their key info for block GC, and tombstones
+   * the part rows. Returns the released quota and fills the two lists.
+   */
+  private long reclaimExpiredParts(OMMetadataManager omMetadataManager,
+      OmMultipartKeyInfo omMultipartKeyInfo, OmMultipartUpload multipartUpload,
+      long trxnLogIndex, List<OmKeyInfo> partsKeyInfoToDelete,
+      List<OmMultipartPartKey> partsTableKeysToDelete) throws IOException {
+    long quotaReleased = 0;
+    if (omMultipartKeyInfo.getSchemaVersion() == 0) {
+      for (PartKeyInfo iterPartKeyInfo : omMultipartKeyInfo
+          .getPartKeyInfoMap()) {
+        quotaReleased += QuotaUtil.getReplicatedSize(
+            iterPartKeyInfo.getPartKeyInfo().getDataSize(),
+            omMultipartKeyInfo.getReplicationConfig());
+      }
+    } else {
+      SortedMap<Integer, OmMultipartPartInfo> tableParts =
+          MultipartPartScanUtil.scanParts(omMetadataManager,
+              multipartUpload.getUploadId());
+      for (Map.Entry<Integer, OmMultipartPartInfo> partEntry
+          : tableParts.entrySet()) {
+        OmMultipartPartInfo part = partEntry.getValue();
+        quotaReleased += QuotaUtil.getReplicatedSize(part.getDataSize(),
+            omMultipartKeyInfo.getReplicationConfig());
+        partsKeyInfoToDelete.add(part.toOmKeyInfo(
+            multipartUpload.getVolumeName(),
+            multipartUpload.getBucketName(),
+            multipartUpload.getKeyName(),
+            omMultipartKeyInfo.getReplicationConfig()));
+        OmMultipartPartKey partKey = OmMultipartPartKey.of(
+            multipartUpload.getUploadId(), partEntry.getKey());
+        partsTableKeysToDelete.add(partKey);
+        omMetadataManager.getMultipartPartsTable().addCacheEntry(
+            new CacheKey<>(partKey), CacheValue.get(trxnLogIndex));
+      }
+    }
+    return quotaReleased;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
@@ -21,7 +21,10 @@ import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.LeveledResource.B
 
 import java.io.IOException;
 import java.nio.file.InvalidPathException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -34,6 +37,8 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
 import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.ozone.om.request.util.OMMultipartUploadUtils;
@@ -177,14 +182,15 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
           .setUpdateID(trxnLogIndex)
           .build();
 
-      // When abort uploaded key, we need to subtract the PartKey length from
-      // the volume usedBytes.
-      long quotaReleased = 0;
-      for (PartKeyInfo iterPartKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
-        quotaReleased += QuotaUtil.getReplicatedSize(
-            iterPartKeyInfo.getPartKeyInfo().getDataSize(),
-            multipartKeyInfo.getReplicationConfig());
-      }
+      // When aborting an upload, subtract every part's replicated size from the
+      // bucket usedBytes. schemaVersion 0 keeps the parts inline; schemaVersion
+      // 1 reads them from the split parts table (cache-aware), synthesizes their
+      // key info for block GC, and tombstones the part rows.
+      List<OmKeyInfo> partsKeyInfoToDelete = new ArrayList<>();
+      List<OmMultipartPartKey> partsTableKeysToDelete = new ArrayList<>();
+      long quotaReleased = reclaimAbortedParts(omMetadataManager,
+          multipartKeyInfo, keyArgs, trxnLogIndex, partsKeyInfoToDelete,
+          partsTableKeysToDelete);
       omBucketInfo.incrUsedBytes(-quotaReleased);
 
       // Update cache of openKeyTable and multipartInfo table.
@@ -198,7 +204,8 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
               CacheValue.get(trxnLogIndex));
 
       omClientResponse = getOmClientResponse(ozoneManager, multipartKeyInfo,
-          multipartKey, multipartOpenKey, omResponse, omBucketInfo);
+          multipartKey, multipartOpenKey, omResponse, omBucketInfo,
+          partsKeyInfoToDelete, partsTableKeysToDelete);
 
       result = Result.SUCCESS;
     } catch (IOException | InvalidPathException ex) {
@@ -240,6 +247,49 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
     return omClientResponse;
   }
 
+  /**
+   * Subtract every part's replicated size from the bucket usedBytes and collect
+   * the parts to reclaim. schemaVersion 0 keeps parts inline; schemaVersion 1
+   * reads them from the split parts table (cache-aware), synthesizes their key
+   * info for block GC, and tombstones the part rows. Returns the released quota
+   * and fills the two lists.
+   */
+  private long reclaimAbortedParts(OMMetadataManager omMetadataManager,
+      OmMultipartKeyInfo multipartKeyInfo,
+      OzoneManagerProtocolProtos.KeyArgs keyArgs, long trxnLogIndex,
+      List<OmKeyInfo> partsKeyInfoToDelete,
+      List<OmMultipartPartKey> partsTableKeysToDelete) throws IOException {
+    String volumeName = keyArgs.getVolumeName();
+    String bucketName = keyArgs.getBucketName();
+    String keyName = keyArgs.getKeyName();
+    String uploadID = keyArgs.getMultipartUploadID();
+    long quotaReleased = 0;
+    if (multipartKeyInfo.getSchemaVersion() == 0) {
+      for (PartKeyInfo iterPartKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
+        quotaReleased += QuotaUtil.getReplicatedSize(
+            iterPartKeyInfo.getPartKeyInfo().getDataSize(),
+            multipartKeyInfo.getReplicationConfig());
+      }
+    } else {
+      SortedMap<Integer, OmMultipartPartInfo> tableParts =
+          MultipartPartScanUtil.scanParts(omMetadataManager, uploadID);
+      for (Map.Entry<Integer, OmMultipartPartInfo> entry
+          : tableParts.entrySet()) {
+        OmMultipartPartInfo part = entry.getValue();
+        quotaReleased += QuotaUtil.getReplicatedSize(part.getDataSize(),
+            multipartKeyInfo.getReplicationConfig());
+        partsKeyInfoToDelete.add(part.toOmKeyInfo(volumeName, bucketName,
+            keyName, multipartKeyInfo.getReplicationConfig()));
+        OmMultipartPartKey partKey =
+            OmMultipartPartKey.of(uploadID, entry.getKey());
+        partsTableKeysToDelete.add(partKey);
+        omMetadataManager.getMultipartPartsTable().addCacheEntry(
+            new CacheKey<>(partKey), CacheValue.get(trxnLogIndex));
+      }
+    }
+    return quotaReleased;
+  }
+
   protected OMClientResponse getOmClientResponse(Exception exception,
       OMResponse.Builder omResponse) {
 
@@ -247,16 +297,20 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
             exception), getBucketLayout());
   }
 
+  @SuppressWarnings("checkstyle:ParameterNumber")
   protected OMClientResponse getOmClientResponse(OzoneManager ozoneManager,
       OmMultipartKeyInfo multipartKeyInfo, String multipartKey,
       String multipartOpenKey, OMResponse.Builder omResponse,
-      OmBucketInfo omBucketInfo) {
+      OmBucketInfo omBucketInfo,
+      List<OmKeyInfo> partsKeyInfoToDelete,
+      List<OmMultipartPartKey> partsTableKeysToDelete) {
 
     OMClientResponse omClientResponse = new S3MultipartUploadAbortResponse(
         omResponse.setAbortMultiPartUploadResponse(
             MultipartUploadAbortResponse.newBuilder()).build(), multipartKey,
         multipartOpenKey, multipartKeyInfo,
-        omBucketInfo.copyObject(), getBucketLayout());
+        omBucketInfo.copyObject(), getBucketLayout(), partsKeyInfoToDelete,
+        partsTableKeysToDelete);
     return omClientResponse;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequestWithFSO.java
@@ -17,10 +17,13 @@
 
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
+import java.util.List;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.s3.multipart.S3MultipartUploadAbortResponseWithFSO;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartUploadAbortResponse;
@@ -47,16 +50,20 @@ public class S3MultipartUploadAbortRequestWithFSO
   }
 
   @Override
+  @SuppressWarnings("checkstyle:ParameterNumber")
   protected OMClientResponse getOmClientResponse(OzoneManager ozoneManager,
       OmMultipartKeyInfo multipartKeyInfo, String multipartKey,
       String multipartOpenKey, OMResponse.Builder omResponse,
-      OmBucketInfo omBucketInfo) {
+      OmBucketInfo omBucketInfo,
+      List<OmKeyInfo> partsKeyInfoToDelete,
+      List<OmMultipartPartKey> partsTableKeysToDelete) {
 
     OMClientResponse omClientResp = new S3MultipartUploadAbortResponseWithFSO(
         omResponse.setAbortMultiPartUploadResponse(
             MultipartUploadAbortResponse.newBuilder()).build(), multipartKey,
         multipartOpenKey, multipartKeyInfo,
-        omBucketInfo.copyObject(), getBucketLayout());
+        omBucketInfo.copyObject(), getBucketLayout(), partsKeyInfoToDelete,
+        partsTableKeysToDelete);
     return omClientResp;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/AbstractS3MultipartAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/AbstractS3MultipartAbortResponse.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.response.s3.multipart;
 
 import jakarta.annotation.Nonnull;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
@@ -29,6 +30,7 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartAbortInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.response.key.OmKeyResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -74,13 +76,30 @@ public abstract class AbstractS3MultipartAbortResponse extends OmKeyResponse {
 
       OmMultipartKeyInfo omMultipartKeyInfo = abortInfo
           .getOmMultipartKeyInfo();
-      // Move all the parts to delete table
-      for (PartKeyInfo partKeyInfo: omMultipartKeyInfo.getPartKeyInfoMap()) {
-        OmKeyInfo currentKeyPartInfo =
-            OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
 
+      // Collect the parts to move to the delete table. schemaVersion 0 keeps
+      // parts inline; schemaVersion 1 carries the synthesized part keys (read
+      // from the split parts table) and also deletes the parts-table rows.
+      List<OmKeyInfo> partsToDelete;
+      if (omMultipartKeyInfo.getSchemaVersion() == 0) {
+        partsToDelete = new ArrayList<>();
+        for (PartKeyInfo partKeyInfo : omMultipartKeyInfo.getPartKeyInfoMap()) {
+          partsToDelete.add(
+              OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo()));
+        }
+      } else {
+        partsToDelete = abortInfo.getPartsKeyInfoToDelete();
+        for (OmMultipartPartKey partKey
+            : abortInfo.getPartsTableKeysToDelete()) {
+          omMetadataManager.getMultipartPartsTable()
+              .deleteWithBatch(batchOperation, partKey);
+        }
+      }
+
+      // Move all the parts to delete table.
+      for (OmKeyInfo currentKeyPartInfo : partsToDelete) {
         // TODO: Similar to open key deletion response, we can check if the
-        //  MPU part actually contains blocks, and only move the to
+        //  MPU part actually contains blocks, and only move it to
         //  deletedTable if it does.
 
         RepeatedOmKeyInfo repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(omBucketInfo.getObjectID(),
@@ -105,6 +124,7 @@ public abstract class AbstractS3MultipartAbortResponse extends OmKeyResponse {
    * Both LEGACY/OBS and FSO have similar abort logic. The only difference
    * is the multipartOpenKey used in the openKeyTable and openFileTable.
    */
+  @SuppressWarnings("checkstyle:ParameterNumber")
   protected void addAbortToBatch(
       OMMetadataManager omMetadataManager,
       BatchOperation batchOperation,
@@ -112,13 +132,17 @@ public abstract class AbstractS3MultipartAbortResponse extends OmKeyResponse {
       String multipartOpenKey,
       OmMultipartKeyInfo omMultipartKeyInfo,
       OmBucketInfo omBucketInfo,
-      BucketLayout bucketLayout) throws IOException {
+      BucketLayout bucketLayout,
+      List<OmKeyInfo> partsKeyInfoToDelete,
+      List<OmMultipartPartKey> partsTableKeysToDelete) throws IOException {
     OmMultipartAbortInfo omMultipartAbortInfo =
         new OmMultipartAbortInfo.Builder()
             .setMultipartKey(multipartKey)
             .setMultipartOpenKey(multipartOpenKey)
             .setMultipartKeyInfo(omMultipartKeyInfo)
             .setBucketLayout(bucketLayout)
+            .setPartsKeyInfoToDelete(partsKeyInfoToDelete)
+            .setPartsTableKeysToDelete(partsTableKeysToDelete)
             .build();
     addAbortToBatch(omMetadataManager, batchOperation, omBucketInfo,
         Collections.singletonList(omMultipartAbortInfo));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3ExpiredMultipartUploadsAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3ExpiredMultipartUploadsAbortResponse.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.response.s3.multipart;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_INFO_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_PARTS_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_FILE_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_KEY_TABLE;
 
@@ -39,7 +40,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
  * Handles response to abort expired MPUs.
  */
 @CleanupTableInfo(cleanupTables = {OPEN_KEY_TABLE, OPEN_FILE_TABLE,
-    DELETED_TABLE, MULTIPART_INFO_TABLE, BUCKET_TABLE})
+    DELETED_TABLE, MULTIPART_INFO_TABLE, MULTIPART_PARTS_TABLE, BUCKET_TABLE})
 public class S3ExpiredMultipartUploadsAbortResponse extends
     AbstractS3MultipartAbortResponse {
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponse.java
@@ -20,15 +20,20 @@ package org.apache.hadoop.ozone.om.response.s3.multipart;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_INFO_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_PARTS_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_KEY_TABLE;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
 import java.io.IOException;
+import java.util.List;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 
@@ -36,7 +41,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
  * Response for Multipart Abort Request.
  */
 @CleanupTableInfo(cleanupTables = {OPEN_KEY_TABLE, DELETED_TABLE,
-    MULTIPART_INFO_TABLE, BUCKET_TABLE})
+    MULTIPART_INFO_TABLE, MULTIPART_PARTS_TABLE, BUCKET_TABLE})
 public class S3MultipartUploadAbortResponse extends
     AbstractS3MultipartAbortResponse {
 
@@ -44,16 +49,23 @@ public class S3MultipartUploadAbortResponse extends
   private String multipartOpenKey;
   private OmMultipartKeyInfo omMultipartKeyInfo;
   private OmBucketInfo omBucketInfo;
+  private List<OmKeyInfo> partsKeyInfoToDelete;
+  private List<OmMultipartPartKey> partsTableKeysToDelete;
 
+  @SuppressWarnings("checkstyle:ParameterNumber")
   public S3MultipartUploadAbortResponse(@Nonnull OMResponse omResponse,
       String multipartKey, String multipartOpenKey,
       @Nonnull OmMultipartKeyInfo omMultipartKeyInfo,
-      @Nonnull OmBucketInfo omBucketInfo, @Nonnull BucketLayout bucketLayout) {
+      @Nonnull OmBucketInfo omBucketInfo, @Nonnull BucketLayout bucketLayout,
+      @Nullable List<OmKeyInfo> partsKeyInfoToDelete,
+      @Nullable List<OmMultipartPartKey> partsTableKeysToDelete) {
     super(omResponse, bucketLayout);
     this.multipartKey = multipartKey;
     this.multipartOpenKey = multipartOpenKey;
     this.omMultipartKeyInfo = omMultipartKeyInfo;
     this.omBucketInfo = omBucketInfo;
+    this.partsKeyInfoToDelete = partsKeyInfoToDelete;
+    this.partsTableKeysToDelete = partsTableKeysToDelete;
   }
 
   /**
@@ -71,6 +83,6 @@ public class S3MultipartUploadAbortResponse extends
       BatchOperation batchOperation) throws IOException {
     addAbortToBatch(omMetadataManager, batchOperation,
         multipartKey, multipartOpenKey, omMultipartKeyInfo, omBucketInfo,
-        getBucketLayout());
+        getBucketLayout(), partsKeyInfoToDelete, partsTableKeysToDelete);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadAbortResponseWithFSO.java
@@ -20,12 +20,17 @@ package org.apache.hadoop.ozone.om.response.s3.multipart;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_INFO_TABLE;
+import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.MULTIPART_PARTS_TABLE;
 import static org.apache.hadoop.ozone.om.codec.OMDBDefinition.OPEN_FILE_TABLE;
 
 import jakarta.annotation.Nonnull;
+import jakarta.annotation.Nullable;
+import java.util.List;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 
@@ -33,17 +38,21 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
  * Response for Multipart Abort Request - prefix layout.
  */
 @CleanupTableInfo(cleanupTables = {OPEN_FILE_TABLE, DELETED_TABLE,
-    MULTIPART_INFO_TABLE, BUCKET_TABLE})
+    MULTIPART_INFO_TABLE, MULTIPART_PARTS_TABLE, BUCKET_TABLE})
 public class S3MultipartUploadAbortResponseWithFSO
     extends S3MultipartUploadAbortResponse {
 
+  @SuppressWarnings("checkstyle:ParameterNumber")
   public S3MultipartUploadAbortResponseWithFSO(@Nonnull OMResponse omResponse,
       String multipartKey, String multipartOpenKey,
       @Nonnull OmMultipartKeyInfo omMultipartKeyInfo,
-      @Nonnull OmBucketInfo omBucketInfo, @Nonnull BucketLayout bucketLayout) {
+      @Nonnull OmBucketInfo omBucketInfo, @Nonnull BucketLayout bucketLayout,
+      @Nullable List<OmKeyInfo> partsKeyInfoToDelete,
+      @Nullable List<OmMultipartPartKey> partsTableKeysToDelete) {
 
     super(omResponse, multipartKey, multipartOpenKey, omMultipartKeyInfo,
-        omBucketInfo, bucketLayout);
+        omBucketInfo, bucketLayout, partsKeyInfoToDelete,
+        partsTableKeysToDelete);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3ExpiredMultipartUploadsAbortRequest.java
@@ -33,20 +33,27 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.utils.UniqueId;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUpload;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
+import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.util.OMMultipartUploadUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -57,6 +64,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Multipa
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.util.Time;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -307,6 +316,187 @@ public class TestS3ExpiredMultipartUploadsAbortRequest
         metrics.getNumExpiredMPUSubmittedForAbort());
     assertEquals(numExistentMPUs, metrics.getNumExpiredMPUAborted());
     assertEquals(numExistentMPUs * numParts, metrics.getNumExpiredMPUPartsAborted());
+  }
+
+  /**
+   * Regression for the expired-MPU abort quota calculation: an EC-replicated
+   * upload must release the stripe-aware {@link QuotaUtil#getReplicatedSize}
+   * from the bucket, NOT {@code dataSize * replicationConfig.getRequiredNodes()}.
+   * For RATIS the two coincide (factor == required nodes), so only an EC config
+   * distinguishes the fix from the pre-fix {@code * keyFactor} bug. RS-3-2 is
+   * used here: its stripe-aware size is far below {@code dataSize * 5}.
+   * Exercises the schemaVersion 1 (split parts table) reclaim branch.
+   */
+  @Test
+  public void testExpiredAbortReleasesEcStripeAwareQuota() throws Exception {
+    this.bucketLayout = BucketLayout.DEFAULT;
+    final String volumeName = UUID.randomUUID().toString();
+    final String bucketName = UUID.randomUUID().toString();
+    final String keyName = UUID.randomUUID().toString();
+
+    // RS-3-2 with the default 1 MiB chunk.
+    final ECReplicationConfig ecConfig = new ECReplicationConfig(3, 2);
+    final long partDataSize = 5 * OzoneConsts.MB;  // spans more than one stripe
+    final long perPartReplicated =
+        QuotaUtil.getReplicatedSize(partDataSize, ecConfig);
+    // Guard the guard: the stripe-aware size must differ from the buggy
+    // dataSize * requiredNodes, else this test would pass on both code paths.
+    assertNotEquals(partDataSize * ecConfig.getRequiredNodes(),
+        perPartReplicated);
+    final long expectedReleased = 2 * perPartReplicated;
+    final long initialUsedBytes = 100 * OzoneConsts.MB;
+
+    OMRequestTestUtils.addVolumeToDB(volumeName, omMetadataManager);
+    OMRequestTestUtils.addBucketToOM(omMetadataManager,
+        OmBucketInfo.newBuilder()
+            .setVolumeName(volumeName)
+            .setBucketName(bucketName)
+            .setBucketLayout(getBucketLayout())
+            .setUsedBytes(initialUsedBytes)
+            .build());
+
+    // Build a schemaVersion 1, EC-replicated parent MPU and seed two equal
+    // parts directly into the split parts table (the v1 reclaim branch reads
+    // the parts table and derives the replicated size from this parent's
+    // replication config).
+    final String uploadID = OMMultipartUploadUtils.getMultipartUploadId();
+    OmKeyInfo mpuKeyInfo = new OmKeyInfo.Builder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .build();
+    OmMultipartKeyInfo multipartKeyInfo = new OmMultipartKeyInfo.Builder()
+        .setUploadID(uploadID)
+        .setReplicationConfig(ecConfig)
+        .setUpdateID(1L)
+        .setSchemaVersion((byte) 1)
+        .build();
+    String mpuDBKey = OMRequestTestUtils.addMultipartInfoToTable(false,
+        mpuKeyInfo, multipartKeyInfo, 1L, omMetadataManager);
+
+    seedV1Part(uploadID, 1, 2L, partDataSize);
+    seedV1Part(uploadID, 2, 3L, partDataSize);
+
+    OMRequest omRequest = doPreExecute(createAbortExpiredMPURequest(
+        volumeName, bucketName, Collections.singletonList(mpuDBKey)));
+    S3ExpiredMultipartUploadsAbortRequest abortRequest =
+        new S3ExpiredMultipartUploadsAbortRequest(omRequest);
+    OMClientResponse omClientResponse =
+        abortRequest.validateAndUpdateCache(ozoneManager, 100L);
+    assertEquals(Status.OK, omClientResponse.getOMResponse().getStatus());
+
+    BatchOperation batchOperation =
+        omMetadataManager.getStore().initBatchOperation();
+    omClientResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    long finalUsedBytes = omMetadataManager.getBucketTable()
+        .get(omMetadataManager.getBucketKey(volumeName, bucketName))
+        .getUsedBytes();
+    assertEquals(initialUsedBytes - expectedReleased, finalUsedBytes,
+        "expired-abort must release the EC stripe-aware replicated size");
+  }
+
+  @Test
+  public void testExpiredAbortReleasesEcStripeAwareQuotaV0() throws Exception {
+    // v0 (inline) counterpart of testExpiredAbortReleasesEcStripeAwareQuota.
+    // The expired-abort EC quota fix changed BOTH the inline (schemaVersion 0)
+    // and split-table (schemaVersion 1) reclaim branches from
+    // dataSize*requiredNodes to the stripe-aware QuotaUtil.getReplicatedSize;
+    // this guards the v0 branch so a regression there cannot pass while only
+    // the v1 case is covered.
+    this.bucketLayout = BucketLayout.DEFAULT;
+    final String volumeName = UUID.randomUUID().toString();
+    final String bucketName = UUID.randomUUID().toString();
+    final String keyName = UUID.randomUUID().toString();
+
+    final ECReplicationConfig ecConfig = new ECReplicationConfig(3, 2);
+    // createPartKeyInfo stores dataSize=100; EC getReplicatedSize(100)=300,
+    // which differs from the buggy 100*requiredNodes=500.
+    final long partDataSize = 100L;
+    final long perPartReplicated =
+        QuotaUtil.getReplicatedSize(partDataSize, ecConfig);
+    assertNotEquals(partDataSize * ecConfig.getRequiredNodes(),
+        perPartReplicated);
+    final long expectedReleased = 2 * perPartReplicated;
+    final long initialUsedBytes = 100 * OzoneConsts.MB;
+
+    OMRequestTestUtils.addVolumeToDB(volumeName, omMetadataManager);
+    OMRequestTestUtils.addBucketToOM(omMetadataManager,
+        OmBucketInfo.newBuilder()
+            .setVolumeName(volumeName)
+            .setBucketName(bucketName)
+            .setBucketLayout(getBucketLayout())
+            .setUsedBytes(initialUsedBytes)
+            .build());
+
+    // Build a schemaVersion 0 (inline), EC-replicated parent MPU with two
+    // inline parts. The v0 reclaim branch reads each part's dataSize and the
+    // replicated size from the parent EC config.
+    final String uploadID = OMMultipartUploadUtils.getMultipartUploadId();
+    OmKeyInfo mpuKeyInfo = new OmKeyInfo.Builder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .build();
+    OmMultipartKeyInfo multipartKeyInfo = new OmMultipartKeyInfo.Builder()
+        .setUploadID(uploadID)
+        .setReplicationConfig(ecConfig)
+        .setUpdateID(1L)
+        .build();
+    multipartKeyInfo.addPartKeyInfo(OMRequestTestUtils.createPartKeyInfo(
+        volumeName, bucketName, keyName, uploadID, 1));
+    multipartKeyInfo.addPartKeyInfo(OMRequestTestUtils.createPartKeyInfo(
+        volumeName, bucketName, keyName, uploadID, 2));
+    String mpuDBKey = OMRequestTestUtils.addMultipartInfoToTable(false,
+        mpuKeyInfo, multipartKeyInfo, 1L, omMetadataManager);
+
+    OMRequest omRequest = doPreExecute(createAbortExpiredMPURequest(
+        volumeName, bucketName, Collections.singletonList(mpuDBKey)));
+    S3ExpiredMultipartUploadsAbortRequest abortRequest =
+        new S3ExpiredMultipartUploadsAbortRequest(omRequest);
+    OMClientResponse omClientResponse =
+        abortRequest.validateAndUpdateCache(ozoneManager, 100L);
+    assertEquals(Status.OK, omClientResponse.getOMResponse().getStatus());
+
+    BatchOperation batchOperation =
+        omMetadataManager.getStore().initBatchOperation();
+    omClientResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    long finalUsedBytes = omMetadataManager.getBucketTable()
+        .get(omMetadataManager.getBucketKey(volumeName, bucketName))
+        .getUsedBytes();
+    assertEquals(initialUsedBytes - expectedReleased, finalUsedBytes,
+        "v0 expired-abort must release the EC stripe-aware replicated size");
+  }
+
+  /**
+   * Seeds one schemaVersion 1 part with the given logical data size into the
+   * split parts table cache (the cache-aware reclaim scan reads it). The part's
+   * own block replication is irrelevant to quota -- the released size derives
+   * from the parent upload's replication config -- so a single empty location
+   * group is attached just to give block GC a well-formed key.
+   */
+  private void seedV1Part(String uploadID, int partNumber, long epoch,
+      long dataSize) {
+    OmKeyInfo partKeyInfo = new OmKeyInfo.Builder()
+        .setVolumeName("vol").setBucketName("bucket").setKeyName("key")
+        .setReplicationConfig(RatisReplicationConfig.getInstance(ONE))
+        .setOmKeyLocationInfos(Collections.singletonList(
+            new OmKeyLocationInfoGroup(0, new ArrayList<>(), true)))
+        .setDataSize(dataSize)
+        .setCreationTime(Time.now())
+        .setModificationTime(Time.now())
+        .setObjectID(1000L + partNumber)
+        .setUpdateID(epoch)
+        .addMetadata(OzoneConsts.ETAG, "etag-" + partNumber)
+        .build();
+    OmMultipartPartInfo part = OmMultipartPartInfo.from(
+        "part-" + partNumber, partNumber, partKeyInfo);
+    omMetadataManager.getMultipartPartsTable().addCacheEntry(
+        new CacheKey<>(OmMultipartPartKey.of(uploadID, partNumber)),
+        CacheValue.get(epoch, part));
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadAbortRequest.java
@@ -18,17 +18,36 @@
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyLocation;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.util.Time;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -93,6 +112,99 @@ public class TestS3MultipartUploadAbortRequest extends TestS3MultipartRequest {
         .getOpenKeyTable(s3MultipartUploadAbortRequest.getBucketLayout())
         .get(multipartOpenKey));
 
+  }
+
+  private List<KeyLocation> abortBlocks(int count, int seed) {
+    List<KeyLocation> keyLocations = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      keyLocations.add(KeyLocation.newBuilder()
+          .setBlockID(HddsProtos.BlockID.newBuilder()
+              .setContainerBlockID(HddsProtos.ContainerBlockID.newBuilder()
+                  .setContainerID(seed + i + 1000L)
+                  .setLocalID(seed + i + 100L).build()))
+          .setOffset(0).setLength(200).setCreateVersion(0L).build());
+    }
+    return keyLocations;
+  }
+
+  private void seedV1Part(String uploadID, int partNumber, long epoch,
+      List<KeyLocation> keyLocations) {
+    List<OmKeyLocationInfo> locInfos = keyLocations.stream()
+        .map(OmKeyLocationInfo::getFromProtobuf).collect(Collectors.toList());
+    OmKeyInfo partKeyInfo = new OmKeyInfo.Builder()
+        .setVolumeName("vol").setBucketName("bucket").setKeyName("key")
+        .setReplicationConfig(
+            RatisReplicationConfig.getInstance(ReplicationFactor.ONE))
+        .setOmKeyLocationInfos(Collections.singletonList(
+            new OmKeyLocationInfoGroup(0, locInfos, true)))
+        .setDataSize(keyLocations.stream()
+            .mapToLong(KeyLocation::getLength).sum())
+        .setCreationTime(Time.now())
+        .setModificationTime(Time.now())
+        .setObjectID(1000L + partNumber)
+        .setUpdateID(epoch)
+        .addMetadata(OzoneConsts.ETAG, "etag-" + partNumber)
+        .build();
+    OmMultipartPartInfo part = OmMultipartPartInfo.from(
+        "part-" + partNumber, partNumber, partKeyInfo);
+    omMetadataManager.getMultipartPartsTable().addCacheEntry(
+        new CacheKey<>(OmMultipartPartKey.of(uploadID, partNumber)),
+        CacheValue.get(epoch, part));
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheV1AbortReclaimsParts()
+      throws Exception {
+    // Post-finalization v1 abort: every part row must be deleted and every
+    // part's blocks tombstoned to the deleted table (the leak this fixes).
+    when(ozoneManager.getVersionManager().getMetadataLayoutVersion())
+        .thenReturn(OMLayoutFeature.MPU_PARTS_TABLE_SPLIT.layoutVersion());
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = getKeyName();
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, getBucketLayout());
+    createParentPath(volumeName, bucketName);
+
+    // Initiate a schemaVersion 1 upload and seed its parts directly into the
+    // split parts table (layout-agnostic; avoids the layout-specific open-key
+    // setup of the commit path).
+    String multipartUploadID =
+        initiateMultipartUploadWithSchemaVersion(volumeName, bucketName,
+            keyName, (byte) 1);
+
+    seedV1Part(multipartUploadID, 1, 2L, abortBlocks(2, 0));
+    seedV1Part(multipartUploadID, 2, 3L, abortBlocks(3, 10));
+    assertNotNull(omMetadataManager.getMultipartPartsTable()
+        .get(OmMultipartPartKey.of(multipartUploadID, 1)));
+    assertNotNull(omMetadataManager.getMultipartPartsTable()
+        .get(OmMultipartPartKey.of(multipartUploadID, 2)));
+
+    OMRequest abortMPURequest = doPreExecuteAbortMPU(volumeName, bucketName,
+        keyName, multipartUploadID);
+    OMClientResponse omClientResponse = getS3MultipartUploadAbortReq(
+        abortMPURequest).validateAndUpdateCache(ozoneManager, 4L);
+    BatchOperation batchOperation =
+        omMetadataManager.getStore().initBatchOperation();
+    omClientResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+
+    String multipartKey = omMetadataManager.getMultipartKey(volumeName,
+        bucketName, keyName, multipartUploadID);
+    assertNull(omMetadataManager.getMultipartInfoTable().get(multipartKey));
+    // Both part rows are reclaimed.
+    assertNull(omMetadataManager.getMultipartPartsTable()
+        .get(OmMultipartPartKey.of(multipartUploadID, 1)));
+    assertNull(omMetadataManager.getMultipartPartsTable()
+        .get(OmMultipartPartKey.of(multipartUploadID, 2)));
+    // The parts' blocks were moved to the deleted table for GC.
+    assertFalse(omMetadataManager.getDeletedTable()
+            .getRangeKVs(null, 100, multipartKey).isEmpty(),
+        "aborted parts' blocks should be moved to the deleted table");
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -343,7 +343,7 @@ public class TestS3MultipartResponse {
       OMResponse omResponse) {
     return new S3MultipartUploadAbortResponse(omResponse, multipartKey,
         multipartOpenKey, omMultipartKeyInfo, omBucketInfo,
-        getBucketLayout());
+        getBucketLayout(), null, null);
   }
 
   public BucketLayout getBucketLayout() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponseWithFSO.java
@@ -98,7 +98,7 @@ public class TestS3MultipartUploadAbortResponseWithFSO
       OzoneManagerProtocolProtos.OMResponse omResponse) {
     return new S3MultipartUploadAbortResponseWithFSO(omResponse, multipartKey,
         multipartOpenKey, omMultipartKeyInfo, omBucketInfo,
-        getBucketLayout());
+        getBucketLayout(), null, null);
   }
 
   @Override


### PR DESCRIPTION
## Summary

**Part 4 of the stacked series** completing the MPU GC optimization (epic HDDS-10611). Stacks on **part 3** (kerneltime/ozone#14, branch `HDDS-14661-3-complete`); the diff here is only the abort/expired-abort side. Final target is `HDDS-14665` (apache/ozone#10062).

## The leak this fixes

Before this change, aborting a `schemaVersion = 1` upload — and the background expired-MPU cleanup — iterated the now-empty inline part map. The result for a v1 upload was a silent triple leak:
- **0 quota released** (the part sizes were never summed),
- **0 blocks tombstoned** (nothing moved to the deleted table),
- **every `multipartPartsTable` row orphaned** (never deleted).

## What it does

Both abort paths (`S3MultipartUploadAbortRequest` and the background `S3ExpiredMultipartUploadsAbortRequest`) now branch on `schemaVersion`. For v1 they read the parts cache-aware from the split table (`MultipartPartScanUtil.scanParts`), and:
- subtract each part's replicated size from the bucket `usedBytes` (using each path's existing quota formula),
- synthesize an `OmKeyInfo` per part (`OmMultipartPartInfo#toOmKeyInfo`) and move its blocks to the deleted table,
- tombstone the part rows in cache and delete them from the DB.

The `OmMultipartAbortInfo` carrier gains the synthesized part keys + the parts-table keys; the shared `AbstractS3MultipartAbortResponse` branches on `schemaVersion` to use them and delete the rows; the three abort responses (object-store, FSO, expired) declare `MULTIPART_PARTS_TABLE` in `@CleanupTableInfo`. `schemaVersion = 0` keeps the inline path unchanged.

## Testing

`mvn -pl hadoop-ozone/ozone-manager test` for the abort + expired-abort request/response classes, object-store and FSO:
- **v0 regression: 32/0.**
- **v1 abort** — seeds parts (with blocks) into the split table, aborts, and asserts every part row is deleted, the multipart info row is gone, and the parts' blocks are moved to the deleted table; runs under both bucket layouts.

This was the out-of-diff leak flagged by the adversarial review of part 3.

## Next (stacked on this branch)

`listParts` v1 (reuses `scanParts`) → Recon (HDDS-14666) → docs + integration; then the GA bar (perf benchmark, soak, finalization runbook).
