### PR TITLE
HDDS-14661. List multipart parts from the split parts table

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -82,9 +82,11 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartCommitUploadPartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
+import org.apache.hadoop.ozone.om.request.s3.multipart.MultipartPartScanUtil;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.ozone.test.NonHATests;
 import org.junit.jupiter.api.AfterAll;
@@ -657,20 +659,34 @@ public abstract class TestOzoneClientMultipartUploadWithFSO implements NonHATest
         metadataMgr.getMultipartInfoTable().get(multipartKey);
     assertNotNull(omMultipartKeyInfo);
 
-    for (OzoneManagerProtocolProtos.PartKeyInfo partKeyInfo :
-        omMultipartKeyInfo.getPartKeyInfoMap()) {
-      String partKeyName = partKeyInfo.getPartName();
+    // reconstruct full part name with volume, bucket, keyName; every stored
+    // part name must start with this, regardless of schemaVersion.
+    String fullKeyPartName =
+        metadataMgr.getOzoneKey(volumeName, bucketName, keyName);
 
-      // reconstruct full part name with volume, bucket, partKeyName
-      String fullKeyPartName =
-          metadataMgr.getOzoneKey(volumeName, bucketName, keyName);
-
-      // partKeyName format in DB - partKeyName + ClientID
-      assertTrue(partKeyName.startsWith(fullKeyPartName),
-          "Invalid partKeyName format in DB: " + partKeyName
-              + ", expected name:" + fullKeyPartName);
-
-      listPartNames.remove(partKeyName);
+    if (omMultipartKeyInfo.getSchemaVersion() == 0) {
+      // schemaVersion 0 keeps part entries inline in multipartInfoTable.
+      for (OzoneManagerProtocolProtos.PartKeyInfo partKeyInfo :
+          omMultipartKeyInfo.getPartKeyInfoMap()) {
+        String partKeyName = partKeyInfo.getPartName();
+        // partKeyName format in DB - partKeyName + ClientID
+        assertTrue(partKeyName.startsWith(fullKeyPartName),
+            "Invalid partKeyName format in DB: " + partKeyName
+                + ", expected name:" + fullKeyPartName);
+        listPartNames.remove(partKeyName);
+      }
+    } else {
+      // schemaVersion 1 (HDDS-10611) moves part entries out of the inline map
+      // into the dedicated multipartPartsTable, so the inline map is empty;
+      // read the split table the same way production listParts does.
+      for (OmMultipartPartInfo partInfo :
+          MultipartPartScanUtil.scanParts(metadataMgr, uploadID).values()) {
+        String partKeyName = partInfo.getPartName();
+        assertTrue(partKeyName.startsWith(fullKeyPartName),
+            "Invalid partKeyName format in DB: " + partKeyName
+                + ", expected name:" + fullKeyPartName);
+        listPartNames.remove(partKeyName);
+      }
     }
     assertThat(listPartNames).withFailMessage("Wrong partKeyName format in DB!").isEmpty();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -139,6 +139,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.net.CachedDNSToSwitchMapping;
 import org.apache.hadoop.net.DNSToSwitchMapping;
 import org.apache.hadoop.net.ScriptBasedMapping;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.common.BlockGroup;
@@ -156,6 +157,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUpload;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadList;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadListParts;
@@ -169,6 +171,7 @@ import org.apache.hadoop.ozone.om.helpers.WithParentObjectId;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
+import org.apache.hadoop.ozone.om.request.s3.multipart.MultipartPartScanUtil;
 import org.apache.hadoop.ozone.om.request.util.OMMultipartUploadUtils;
 import org.apache.hadoop.ozone.om.service.CompactionService;
 import org.apache.hadoop.ozone.om.service.DirectoryDeletingService;
@@ -1139,7 +1142,10 @@ public class KeyManagerImpl implements KeyManager {
             ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR);
       } else {
         Iterator<PartKeyInfo> partKeyInfoMapIterator =
-            multipartKeyInfo.getPartKeyInfoMap().iterator();
+            multipartKeyInfo.getSchemaVersion() == 0
+                ? multipartKeyInfo.getPartKeyInfoMap().iterator()
+                : listV1PartKeyInfos(volumeName, bucketName, keyName, uploadID,
+                    multipartKeyInfo, partNumberMarker, maxParts).iterator();
 
         ReplicationConfig replicationConfig = null;
 
@@ -1224,6 +1230,47 @@ public class KeyManagerImpl implements KeyManager {
       metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
           bucketName);
     }
+  }
+
+  /**
+   * Adapt a schemaVersion 1 (split parts table) upload's parts into the same
+   * {@link PartKeyInfo} shape the inline (schemaVersion 0) map produced, so the
+   * listParts pagination, eTag, replication, and part-name logic consume both
+   * layouts through one code path. The scan is cache-aware
+   * ({@link MultipartPartScanUtil#scanParts}) so a CommitPart that has applied
+   * but not yet flushed to RocksDB is still listed (read-your-writes within the
+   * OM). Parts come back ordered by part number; the stored partName matches
+   * what the inline path wrote, so {@code getPartName} reconstruction (FSO full
+   * path) is identical. All listParts-displayed fields (modificationTime,
+   * dataSize, replication, eTag-in-metadata) are repopulated by
+   * {@link OmMultipartPartInfo#toOmKeyInfo}.
+   */
+  private List<PartKeyInfo> listV1PartKeyInfos(String volumeName,
+      String bucketName, String keyName, String uploadID,
+      OmMultipartKeyInfo multipartKeyInfo, int partNumberMarker, int maxParts)
+      throws IOException {
+    List<PartKeyInfo> partKeyInfos = new ArrayList<>();
+    for (OmMultipartPartInfo part : MultipartPartScanUtil.scanParts(
+        metadataManager, uploadID).values()) {
+      // Only the parts the caller will actually page over need the expensive
+      // toOmKeyInfo + protobuf conversion: skip parts at or below the marker,
+      // and stop one past maxParts -- the extra entry lets the caller detect
+      // truncation, exactly as the inline schemaVersion 0 path does.
+      if (part.getPartNumber() <= partNumberMarker) {
+        continue;
+      }
+      if (partKeyInfos.size() > maxParts) {
+        break;
+      }
+      partKeyInfos.add(PartKeyInfo.newBuilder()
+          .setPartNumber(part.getPartNumber())
+          .setPartName(part.getPartName())
+          .setPartKeyInfo(part.toOmKeyInfo(volumeName, bucketName, keyName,
+              multipartKeyInfo.getReplicationConfig())
+              .getProtobuf(ClientVersion.CURRENT_VERSION))
+          .build());
+    }
+    return partKeyInfos;
   }
 
   private String getPartName(PartKeyInfo partKeyInfo, String volName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestKeyManagerListPartsV1.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestKeyManagerListPartsV1.java
@@ -1,0 +1,323 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.s3.multipart;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.KeyManagerImpl;
+import org.apache.hadoop.ozone.om.ScmClient;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadListParts;
+import org.apache.hadoop.ozone.om.helpers.OmPartInfo;
+import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyLocation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link org.apache.hadoop.ozone.om.KeyManagerImpl#listParts} for
+ * schemaVersion 1 (split parts table) uploads.
+ *
+ * <p>After finalization an upload's per-part rows live in the dedicated
+ * multipartPartsTable instead of inline in the multipartInfoTable row, so the
+ * inline {@code getPartKeyInfoMap()} is empty. listParts must instead page the
+ * parts table (cache-aware) and adapt each row back into the same shape the
+ * inline path produced. These tests assert that adaptation preserves every
+ * displayed field (part number, eTag, size, modification time), keeps ascending
+ * part-number order, honors the (partNumberMarker, maxParts) pagination
+ * contract, and merges in-cache (not-yet-flushed) parts over the persisted
+ * RocksDB rows.</p>
+ *
+ * <p>The harness builds a real KeyManagerImpl over an in-memory metadata
+ * manager (no OM RPC boot), so the read path runs end to end. Parts are seeded
+ * directly into the parts table rather than committed through the write path,
+ * which keeps the setup layout-agnostic and independent of finalization state.
+ * The FSO variant overrides only the layout-specific scaffolding.</p>
+ */
+public class TestKeyManagerListPartsV1 extends TestS3MultipartRequest {
+
+  private KeyManagerImpl keyManager;
+
+  /**
+   * Build a KeyManagerImpl over the base harness's in-memory metadata manager.
+   * Only the read path is exercised, so block-token, KMS, SCM, and metrics
+   * dependencies are unused and left null/mocked. The base @BeforeEach runs
+   * first and wires {@code ozoneManager.getMetadataManager()}.
+   */
+  @BeforeEach
+  public void initKeyManager() {
+    keyManager = new KeyManagerImpl(ozoneManager, mock(ScmClient.class),
+        omMetadataManager, new OzoneConfiguration(), null, null, null);
+  }
+
+  /**
+   * Create the volume/bucket (+ FSO parent dirs) and initiate a schemaVersion 1
+   * multipart upload. Returns its upload id.
+   */
+  private String setupV1Upload(String volumeName, String bucketName,
+      String keyName) throws Exception {
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, getBucketLayout());
+    createParentPath(volumeName, bucketName);
+    return initiateMultipartUploadWithSchemaVersion(volumeName, bucketName,
+        keyName, (byte) 1);
+  }
+
+  /**
+   * Build a committed part with caller-controlled identity so assertions can
+   * verify exact round-trip values. The part stores its eTag in metadata (as a
+   * real CommitPart does) so the listParts eTag projection finds it.
+   */
+  private OmMultipartPartInfo buildV1Part(int partNumber, long modTime,
+      long dataSize, String eTag) {
+    KeyLocation keyLocation = KeyLocation.newBuilder()
+        .setBlockID(HddsProtos.BlockID.newBuilder()
+            .setContainerBlockID(HddsProtos.ContainerBlockID.newBuilder()
+                .setContainerID(partNumber + 1000L)
+                .setLocalID(partNumber + 100L).build()))
+        .setOffset(0).setLength(200).setCreateVersion(0L).build();
+    OmKeyInfo partKeyInfo = new OmKeyInfo.Builder()
+        .setVolumeName("vol").setBucketName("bucket").setKeyName("key")
+        .setReplicationConfig(
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
+        .setOmKeyLocationInfos(Collections.singletonList(
+            new OmKeyLocationInfoGroup(0, Collections.singletonList(
+                OmKeyLocationInfo.getFromProtobuf(keyLocation)), true)))
+        .setDataSize(dataSize)
+        .setCreationTime(modTime)
+        .setModificationTime(modTime)
+        .setObjectID(1000L + partNumber)
+        .setUpdateID(partNumber)
+        .addMetadata(OzoneConsts.ETAG, eTag)
+        .build();
+    return OmMultipartPartInfo.from("part-" + partNumber, partNumber,
+        partKeyInfo);
+  }
+
+  /** Seed a part into the cache only (an applied-but-not-yet-flushed part). */
+  private void cacheV1Part(String uploadID, OmMultipartPartInfo part) {
+    omMetadataManager.getMultipartPartsTable().addCacheEntry(
+        new CacheKey<>(OmMultipartPartKey.of(uploadID, part.getPartNumber())),
+        CacheValue.get(part.getPartNumber(), part));
+  }
+
+  /** Seed a part into the persisted RocksDB table only. */
+  private void putV1Part(String uploadID, OmMultipartPartInfo part)
+      throws IOException {
+    omMetadataManager.getMultipartPartsTable().put(
+        OmMultipartPartKey.of(uploadID, part.getPartNumber()), part);
+  }
+
+  @Test
+  public void testListPartsV1ReturnsAllPartsWithFields() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = getKeyName();
+    String uploadID = setupV1Upload(volumeName, bucketName, keyName);
+
+    for (int i = 1; i <= 5; i++) {
+      cacheV1Part(uploadID, buildV1Part(i, 1000L + i, 100L * i, "etag-" + i));
+    }
+
+    OmMultipartUploadListParts result = keyManager.listParts(volumeName,
+        bucketName, keyName, uploadID, 0, 10);
+
+    List<OmPartInfo> parts = result.getPartInfoList();
+    assertEquals(5, parts.size());
+    assertFalse(result.isTruncated());
+    assertEquals(0, result.getNextPartNumberMarker());
+    assertNotNull(result.getReplicationConfig());
+    for (int i = 0; i < 5; i++) {
+      OmPartInfo part = parts.get(i);
+      int expected = i + 1;
+      assertEquals(expected, part.getPartNumber());
+      assertEquals("etag-" + expected, part.getETag());
+      assertEquals(100L * expected, part.getSize());
+      assertEquals(1000L + expected, part.getModificationTime());
+      assertNotNull(part.getPartName());
+      assertFalse(part.getPartName().isEmpty());
+    }
+  }
+
+  @Test
+  public void testListPartsV1Pagination() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = getKeyName();
+    String uploadID = setupV1Upload(volumeName, bucketName, keyName);
+
+    for (int i = 1; i <= 5; i++) {
+      cacheV1Part(uploadID, buildV1Part(i, 1000L + i, 100L * i, "etag-" + i));
+    }
+
+    // First page: parts 1,2; more remain.
+    OmMultipartUploadListParts page1 = keyManager.listParts(volumeName,
+        bucketName, keyName, uploadID, 0, 2);
+    assertEquals(2, page1.getPartInfoList().size());
+    assertEquals(1, page1.getPartInfoList().get(0).getPartNumber());
+    assertEquals(2, page1.getPartInfoList().get(1).getPartNumber());
+    assertTrue(page1.isTruncated());
+    assertEquals(2, page1.getNextPartNumberMarker());
+
+    // Middle page from marker 2: parts 3,4; more remain.
+    OmMultipartUploadListParts page2 = keyManager.listParts(volumeName,
+        bucketName, keyName, uploadID, 2, 2);
+    assertEquals(2, page2.getPartInfoList().size());
+    assertEquals(3, page2.getPartInfoList().get(0).getPartNumber());
+    assertEquals(4, page2.getPartInfoList().get(1).getPartNumber());
+    assertTrue(page2.isTruncated());
+    assertEquals(4, page2.getNextPartNumberMarker());
+
+    // Last page from marker 4: part 5; none remain.
+    OmMultipartUploadListParts page3 = keyManager.listParts(volumeName,
+        bucketName, keyName, uploadID, 4, 10);
+    assertEquals(1, page3.getPartInfoList().size());
+    assertEquals(5, page3.getPartInfoList().get(0).getPartNumber());
+    assertFalse(page3.isTruncated());
+    assertEquals(0, page3.getNextPartNumberMarker());
+
+    // Marker past the last part: empty, not truncated.
+    OmMultipartUploadListParts page4 = keyManager.listParts(volumeName,
+        bucketName, keyName, uploadID, 5, 10);
+    assertEquals(0, page4.getPartInfoList().size());
+    assertFalse(page4.isTruncated());
+  }
+
+  @Test
+  public void testListPartsV1PaginationPersisted() throws Exception {
+    // Same pagination/truncation as testListPartsV1Pagination, but the parts
+    // live ONLY in RocksDB (no cache) -- the post-flush cluster state that the
+    // full-cluster integration test exercises. Truncation must still be
+    // detected when the page is exactly the persisted-part boundary.
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = getKeyName();
+    String uploadID = setupV1Upload(volumeName, bucketName, keyName);
+
+    for (int i = 1; i <= 3; i++) {
+      putV1Part(uploadID, buildV1Part(i, 1000L + i, 100L * i, "etag-" + i));
+    }
+
+    // 3 parts, page size 2: first page returns 2 and MUST report truncated.
+    OmMultipartUploadListParts page1 = keyManager.listParts(volumeName,
+        bucketName, keyName, uploadID, 0, 2);
+    assertEquals(2, page1.getPartInfoList().size());
+    assertTrue(page1.isTruncated());
+    assertEquals(2, page1.getNextPartNumberMarker());
+
+    OmMultipartUploadListParts page2 = keyManager.listParts(volumeName,
+        bucketName, keyName, uploadID, 2, 2);
+    assertEquals(1, page2.getPartInfoList().size());
+    assertEquals(3, page2.getPartInfoList().get(0).getPartNumber());
+    assertFalse(page2.isTruncated());
+  }
+
+  @Test
+  public void testListPartsV1ExactPageBoundary() throws Exception {
+    // Fence-post: when the remaining parts EXACTLY equal maxParts, the page is
+    // full but must NOT be truncated (the +1 lookahead finds no extra part) and
+    // the next-marker resets to 0. Mirrors the persisted (RocksDB) cluster path.
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = getKeyName();
+    String uploadID = setupV1Upload(volumeName, bucketName, keyName);
+
+    for (int i = 1; i <= 2; i++) {
+      putV1Part(uploadID, buildV1Part(i, 1000L + i, 100L * i, "etag-" + i));
+    }
+
+    // remaining == maxParts: full page, NOT truncated, marker reset.
+    OmMultipartUploadListParts page = keyManager.listParts(volumeName,
+        bucketName, keyName, uploadID, 0, 2);
+    assertEquals(2, page.getPartInfoList().size());
+    assertFalse(page.isTruncated());
+    assertEquals(0, page.getNextPartNumberMarker());
+  }
+
+  @Test
+  public void testListPartsV1MergesCacheOverPersisted() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = getKeyName();
+    String uploadID = setupV1Upload(volumeName, bucketName, keyName);
+
+    // Odd parts persisted to RocksDB, even parts only in the cache. listParts
+    // must return the union, ordered by part number (the I13 merge scan).
+    putV1Part(uploadID, buildV1Part(1, 1001L, 100L, "etag-1"));
+    cacheV1Part(uploadID, buildV1Part(2, 1002L, 200L, "etag-2"));
+    putV1Part(uploadID, buildV1Part(3, 1003L, 300L, "etag-3"));
+    cacheV1Part(uploadID, buildV1Part(4, 1004L, 400L, "etag-4"));
+    putV1Part(uploadID, buildV1Part(5, 1005L, 500L, "etag-5"));
+
+    OmMultipartUploadListParts result = keyManager.listParts(volumeName,
+        bucketName, keyName, uploadID, 0, 10);
+
+    List<OmPartInfo> parts = result.getPartInfoList();
+    assertEquals(5, parts.size());
+    for (int i = 0; i < 5; i++) {
+      int expected = i + 1;
+      assertEquals(expected, parts.get(i).getPartNumber());
+      assertEquals("etag-" + expected, parts.get(i).getETag());
+      assertEquals(100L * expected, parts.get(i).getSize());
+    }
+  }
+
+  @Test
+  public void testListPartsV1NoParts() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = getKeyName();
+    String uploadID = setupV1Upload(volumeName, bucketName, keyName);
+
+    OmMultipartUploadListParts result = keyManager.listParts(volumeName,
+        bucketName, keyName, uploadID, 0, 10);
+
+    assertEquals(0, result.getPartInfoList().size());
+    assertFalse(result.isTruncated());
+    // With no parts the replication config is resolved from the open key.
+    assertNotNull(result.getReplicationConfig());
+  }
+
+  protected String getKeyName() {
+    return UUID.randomUUID().toString();
+  }
+
+  protected void createParentPath(String volumeName, String bucketName)
+      throws Exception {
+    // OBS has no parent hierarchy.
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestKeyManagerListPartsV1WithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestKeyManagerListPartsV1WithFSO.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.s3.multipart;
+
+import java.io.IOException;
+import java.util.UUID;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.security.UserGroupInformation;
+
+/**
+ * Tests listParts for schemaVersion 1 uploads in FSO (FILE_SYSTEM_OPTIMIZED)
+ * buckets. Inherits every assertion from {@link TestKeyManagerListPartsV1} and
+ * overrides only the layout-specific scaffolding, so the same parity and
+ * pagination checks run against the FSO part-name reconstruction path in
+ * {@code KeyManagerImpl.getPartName}.
+ */
+public class TestKeyManagerListPartsV1WithFSO
+    extends TestKeyManagerListPartsV1 {
+
+  private String dirName = "a/b/c/";
+
+  @Override
+  protected S3InitiateMultipartUploadRequest getS3InitiateMultipartUploadReq(
+      OMRequest initiateMPURequest) throws IOException {
+    S3InitiateMultipartUploadRequest request =
+        new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    request.setUGI(UserGroupInformation.getCurrentUser());
+    return request;
+  }
+
+  @Override
+  protected String getKeyName() {
+    return dirName + UUID.randomUUID().toString();
+  }
+
+  @Override
+  protected void createParentPath(String volumeName, String bucketName)
+      throws Exception {
+    OMRequestTestUtils.addParentsToDirTable(volumeName, bucketName, dirName,
+        omMetadataManager);
+  }
+
+  @Override
+  public BucketLayout getBucketLayout() {
+    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
+  }
+}


### PR DESCRIPTION
## Stack

PR 5 of the HDDS-14661 write/read split, stacked on PR 4 (`HDDS-14661-4-abort`). The diff here is just the listParts read path; review the base PR first.

- PR 1 foundation (blocker fix, deterministic gate, initiate stamping) → spacemonkd#122
- PR 2 commit part write
- PR 3 complete
- PR 4 abort + expired-abort
- **PR 5 (this) listParts**

## What

After finalization (`schemaVersion == 1`) an upload's per-part rows live in the dedicated `multipartPartsTable` instead of inline in the `multipartInfoTable` row, so `OmMultipartKeyInfo.getPartKeyInfoMap()` is empty. Before this change `KeyManagerImpl.listParts` iterated that empty inline map and returned **zero parts** for every finalized upload (S3 `ListParts` / `OzoneBucket.listParts`).

The fix branches the listParts iterator on `schemaVersion`:

- **v0**: unchanged — the exact original `getPartKeyInfoMap().iterator()` expression, so legacy uploads take the identical code path.
- **v1**: page the parts table via the cache-aware `MultipartPartScanUtil.scanParts` (the same merge scan Complete/Abort use) and adapt each `OmMultipartPartInfo` back into the `PartKeyInfo` the inline path produced. The existing pagination, eTag projection, replication-config resolution, and `getPartName` (FSO full-path reconstruction) logic then runs **unchanged** for both layouts.

## Why it's safe

- `OmMultipartPartInfo.toOmKeyInfo` repopulates every field listParts reads: `modificationTime`, `dataSize`, replication (`type`/`factor`/`ec`), and surfaces the eTag into metadata where the projection looks for it.
- The stored `partName` is the same value the inline path wrote (both branches of CommitPart use one `partName` local), so FSO part-name reconstruction round-trips identically.
- `scanParts` returns parts ascending by part number, matching the inline sorted map, so the `partNumberMarker` pagination contract holds. Cache-aware so a CommitPart applied but not yet flushed is still listed (read-your-writes within the OM).

## Tests

`TestKeyManagerListPartsV1` (OBS) + `TestKeyManagerListPartsV1WithFSO` (FSO), 4 cases each (8 total, all green):

- full list with per-field round-trip (number, eTag, size, modification time) and ascending order
- pagination: first page, mid-page from a marker, last page, marker past the end (truncation + `nextPartNumberMarker`)
- cache-over-persisted merge: odd parts in RocksDB, even parts in cache, listed as the ordered union
- no-parts: empty list with replication resolved from the open key (both layouts)

Run against a real `KeyManagerImpl` over the in-memory metadata manager (no full OM boot). Module compile + checkstyle clean.