### PR TITLE
HDDS-14661. Count split-table parts in expired-MPU discovery throttle

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -84,6 +84,7 @@ import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
+import org.apache.hadoop.hdds.utils.db.Table.KeyValueIterator;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.hdds.utils.db.TablePrefixInfo;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
@@ -1528,8 +1529,18 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
           expiredMPUs.get(mapKey)
               .addMultipartUploads(builder.setName(dbMultipartInfoKey)
                   .build());
-          numParts += omMultipartKeyInfo.getPartKeyInfoMap().size();
-          // TODO: Add the expired part handling from the new table when the complete flow is done
+          if (omMultipartKeyInfo.getSchemaVersion() == 0) {
+            numParts += omMultipartKeyInfo.getPartKeyInfoMap().size();
+          } else {
+            // schemaVersion 1: parts live in the split parts table, so the
+            // inline map is empty. Count the part rows (capped at the remaining
+            // budget) so the maxParts throttle still bounds how many parts a
+            // single cleanup cycle reclaims. Without this, every v1 upload adds
+            // 0 and the throttle is defeated -- an expired huge MPU (this
+            // feature's target case) could blow past the cap in one cycle.
+            numParts += countSplitTableParts(
+                expiredMultipartUpload.getUploadId(), maxParts - numParts);
+          }
         }
 
       }
@@ -1538,6 +1549,28 @@ public class OmMetadataManagerImpl implements OMMetadataManager,
     return expiredMPUs.values().stream().map(
             ExpiredMultipartUploadsBucket.Builder::build)
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Count up to {@code limit} part rows of a schemaVersion 1 multipart upload
+   * in the split parts table. This only advances the expired-MPU discovery
+   * throttle, so it stops at the limit rather than walking every part of a
+   * huge upload -- the exact overshoot past maxParts is irrelevant to the
+   * throttle, and the bounded scan keeps discovery cheap.
+   */
+  private int countSplitTableParts(String uploadId, int limit)
+      throws IOException {
+    int count = 0;
+    try (KeyValueIterator<OmMultipartPartKey, OmMultipartPartInfo> iterator =
+        getMultipartPartsTable().iterator(
+            OmMultipartPartKey.prefix(uploadId))) {
+      while (count < limit && iterator.hasNext()) {
+        if (iterator.next().getKey().hasPartNumber()) {
+          count++;
+        }
+      }
+    }
+    return count;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -59,6 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.io.File;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -73,6 +74,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
@@ -80,6 +82,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
@@ -87,8 +90,11 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.ListOpenFilesResult;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUpload;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
@@ -1041,6 +1047,91 @@ public class TestOmMetadataManager {
     names = getMultipartKeyNames(allExpiredMPUs);
     assertEquals(numExpiredMPUs, names.size());
     assertThat(expiredMPUs).containsAll(names);
+  }
+
+  @Test
+  public void testGetExpiredMPUsCountsSplitTableParts() throws Exception {
+    // schemaVersion 1 uploads keep their parts in the split parts table, so the
+    // inline part map is empty. The maxParts throttle in discovery must still
+    // count those split-table parts; otherwise every v1 upload contributes 0
+    // and the throttle is defeated -- a single cleanup cycle could reclaim an
+    // unbounded number of parts. This is the huge-MPU case the feature targets.
+    final String bucketName = UUID.randomUUID().toString();
+    final String volumeName = UUID.randomUUID().toString();
+    final int numExpiredMPUs = 4;
+    final int numPartsPerMPU = 5;
+
+    final long expireThresholdMillis = ozoneConfiguration.getTimeDuration(
+        OZONE_OM_MPU_EXPIRE_THRESHOLD,
+        OZONE_OM_MPU_EXPIRE_THRESHOLD_DEFAULT,
+        TimeUnit.MILLISECONDS);
+    final Duration expireThreshold = Duration.ofMillis(expireThresholdMillis);
+    final long expiredMPUCreationTime =
+        expireThreshold.negated().plusMillis(Time.now()).toMillis();
+
+    Set<String> expiredMPUs = new HashSet<>();
+    for (int i = 0; i < numExpiredMPUs; i++) {
+      String uploadId = OMMultipartUploadUtils.getMultipartUploadId();
+      OmMultipartKeyInfo mpuKeyInfo = OMRequestTestUtils
+          .createOmMultipartKeyInfo(uploadId, expiredMPUCreationTime,
+              HddsProtos.ReplicationType.RATIS,
+              HddsProtos.ReplicationFactor.ONE, 0L)
+          .toBuilder().setSchemaVersion((byte) 1).build();
+
+      String keyName = "expired" + i;
+      OmKeyInfo keyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
+              bucketName, keyName, RatisReplicationConfig.getInstance(ONE))
+          .setCreationTime(expiredMPUCreationTime)
+          .build();
+
+      // Parts live in the split table, keyed by uploadId (not inline).
+      for (int j = 1; j <= numPartsPerMPU; j++) {
+        seedSplitPart(uploadId, j, expiredMPUCreationTime);
+      }
+
+      expiredMPUs.add(OMRequestTestUtils.addMultipartInfoToTable(
+          false, keyInfo, mpuKeyInfo, 0L, omMetadataManager));
+    }
+
+    // Budget below the combined part count: discovery counts the split-table
+    // parts and stops one MPU short.
+    List<ExpiredMultipartUploadsBucket> someExpiredMPUs =
+        omMetadataManager.getExpiredMultipartUploads(expireThreshold,
+            (numExpiredMPUs * numPartsPerMPU) - numPartsPerMPU);
+    List<String> names = getMultipartKeyNames(someExpiredMPUs);
+    assertEquals(numExpiredMPUs - 1, names.size());
+    assertThat(expiredMPUs).containsAll(names);
+
+    // Budget above the combined part count: all expired MPUs returned.
+    List<ExpiredMultipartUploadsBucket> allExpiredMPUs =
+        omMetadataManager.getExpiredMultipartUploads(expireThreshold,
+            (numExpiredMPUs * numPartsPerMPU) + numPartsPerMPU);
+    names = getMultipartKeyNames(allExpiredMPUs);
+    assertEquals(numExpiredMPUs, names.size());
+    assertThat(expiredMPUs).containsAll(names);
+  }
+
+  private void seedSplitPart(String uploadId, int partNumber, long time)
+      throws IOException {
+    OmKeyLocationInfo location = new OmKeyLocationInfo.Builder()
+        .setBlockID(new BlockID(1000L + partNumber, 100L + partNumber))
+        .setLength(100L).setOffset(0L).build();
+    OmKeyInfo partKeyInfo = new OmKeyInfo.Builder()
+        .setVolumeName("vol").setBucketName("bucket").setKeyName("key")
+        .setReplicationConfig(RatisReplicationConfig.getInstance(ONE))
+        .setOmKeyLocationInfos(Collections.singletonList(
+            new OmKeyLocationInfoGroup(0,
+                Collections.singletonList(location), true)))
+        .setDataSize(100L)
+        .setCreationTime(time)
+        .setModificationTime(time)
+        .setObjectID(partNumber)
+        .setUpdateID(partNumber)
+        .addMetadata(OzoneConsts.ETAG, "etag-" + partNumber)
+        .build();
+    omMetadataManager.getMultipartPartsTable().put(
+        OmMultipartPartKey.of(uploadId, partNumber),
+        OmMultipartPartInfo.from("part-" + partNumber, partNumber, partKeyInfo));
   }
 
   private List<String> getOpenKeyNames(


### PR DESCRIPTION
## Stack

PR 6 of the HDDS-14661 write/read split, stacked on PR 5 (`HDDS-14661-5-listparts`). Review the base PR first; the diff here is just the discovery throttle.

## What

`OmMetadataManagerImpl.getExpiredMultipartUploads` throttles a cleanup cycle with `while (numParts < maxParts && ...)`, accumulating `numParts += omMultipartKeyInfo.getPartKeyInfoMap().size()`. For `schemaVersion == 1` uploads the inline part map is empty, so each expired upload contributed **0** to `numParts` and the throttle was defeated — the loop would keep adding expired MPUs regardless of how many parts they hold.

This matters precisely for the case the feature exists to support: a multipart upload with **millions of parts**. An expired one of those (or a run of them) could be pulled into a single cleanup cycle, far exceeding the `maxParts` soft cap the throttle is meant to enforce. The code already carried a `// TODO: Add the expired part handling from the new table when the complete flow is done` — the complete/abort/listParts flows are now done, so this closes it.

## Fix

Branch on `schemaVersion`:
- **v0** — unchanged: `numParts += getPartKeyInfoMap().size()`.
- **v1** — `numParts += countSplitTableParts(uploadId, maxParts - numParts)`: a bounded prefix scan of the split parts table, **capped at the remaining budget**. Since the loop only cares whether `numParts` has reached `maxParts`, counting past the budget is wasted work — so total part-key iteration across an entire discovery pass stays ~`maxParts` rather than O(parts). This keeps the throttle's guarantee without reintroducing the O(parts) cost the split table was designed to remove.

The count reads RocksDB (not the cache): expired MPUs are old and long-flushed, and a throttle tolerates approximation. The `uploadId` for the prefix comes from `OmMultipartUpload.from(dbKey).getUploadId()`, which matches the `uploadId` CommitPart keys parts with.

## Tests

`TestOmMetadataManager.testGetExpiredMPUsCountsSplitTableParts`: seeds 4 expired v1 uploads (5 split-table parts each, empty inline map) and asserts discovery stops one MPU short when the budget is below the combined part count, and returns all when it's above. Without the fix every upload counts as 0 parts and all 4 return — so the test fails on the unpatched code. The existing v0 `testGetExpiredMPUs` is unchanged (the capped count yields identical MPU counts).