### PR TITLE
HDDS-14661. Map split-table parts in the container-key-mapping debug tool

### DIFF
--- a/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/om/ContainerToKeyMapping.java
+++ b/hadoop-ozone/cli-debug/src/main/java/org/apache/hadoop/ozone/debug/om/ContainerToKeyMapping.java
@@ -52,7 +52,10 @@ import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartKeyInfo;
 import picocli.CommandLine;
@@ -100,6 +103,7 @@ public class ContainerToKeyMapping extends AbstractSubcommand implements Callabl
   private Table<String, OmKeyInfo> openFileTable;
   private Table<String, OmKeyInfo> openKeyTable;
   private Table<String, OmMultipartKeyInfo> multipartInfoTable;
+  private Table<OmMultipartPartKey, OmMultipartPartInfo> multipartPartsTable;
   private DBStore dirTreeDbStore;
   private Table<Long, String> dirTreeTable;
   // Cache volume IDs to avoid repeated lookups
@@ -138,6 +142,7 @@ public class ContainerToKeyMapping extends AbstractSubcommand implements Callabl
       openFileTable = OMDBDefinition.OPEN_FILE_TABLE_DEF.getTable(omDbStore, CacheType.NO_CACHE);
       openKeyTable = OMDBDefinition.OPEN_KEY_TABLE_DEF.getTable(omDbStore, CacheType.NO_CACHE);
       multipartInfoTable = OMDBDefinition.MULTIPART_INFO_TABLE_DEF.getTable(omDbStore, CacheType.NO_CACHE);
+      multipartPartsTable = OMDBDefinition.MULTIPART_PARTS_TABLE_DEF.getTable(omDbStore, CacheType.NO_CACHE);
 
       retrieve(dbPath, writer, containerIDs);
     } catch (Exception e) {
@@ -317,11 +322,34 @@ public class ContainerToKeyMapping extends AbstractSubcommand implements Callabl
         String dbKey = entry.getKey();
         OmMultipartKeyInfo mpuInfo = entry.getValue();
 
-        // Collect all target containers that have parts of this MPU
+        // Collect all target containers that have parts of this MPU. Before
+        // finalization (schemaVersion 0) parts are inline in this row; after
+        // finalization (schemaVersion 1) they live in the split parts table,
+        // keyed by uploadId.
         Set<Long> matchedContainers = new HashSet<>();
-        for (PartKeyInfo partKeyInfo : mpuInfo.getPartKeyInfoMap()) {
-          OmKeyInfo partKey = OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
-          matchedContainers.addAll(getKeyContainers(partKey, containerIds));
+        if (mpuInfo.getSchemaVersion() == 0) {
+          for (PartKeyInfo partKeyInfo : mpuInfo.getPartKeyInfoMap()) {
+            OmKeyInfo partKey = OmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+            matchedContainers.addAll(getKeyContainers(partKey, containerIds));
+          }
+        } else if (multipartPartsTable == null) {
+          // An OM DB created before the parts-table split has no
+          // multipartPartsTable; schemaVersion 1 uploads cannot exist there, so
+          // there is nothing to scan.
+          err().println("multipartPartsTable not available (older OM DB?); "
+              + "skipping schemaVersion 1 MPU parts for " + dbKey);
+        } else {
+          try (Table.KeyValueIterator<OmMultipartPartKey, OmMultipartPartInfo> partIterator =
+              multipartPartsTable.iterator(OmMultipartPartKey.prefix(mpuInfo.getUploadID()))) {
+            while (partIterator.hasNext()) {
+              OmMultipartPartInfo part = partIterator.next().getValue();
+              if (part == null) {
+                continue;
+              }
+              matchedContainers.addAll(
+                  getContainersFromLocations(part.getKeyLocationInfos(), containerIds));
+            }
+          }
         }
 
         if (!matchedContainers.isEmpty()) {
@@ -336,16 +364,22 @@ public class ContainerToKeyMapping extends AbstractSubcommand implements Callabl
   }
 
   private Set<Long> getKeyContainers(OmKeyInfo keyInfo, Set<Long> targetContainerIds) {
-    Set<Long> keyContainers = new HashSet<>();
-    keyInfo.getKeyLocationVersions().forEach(
+    return getContainersFromLocations(keyInfo.getKeyLocationVersions(),
+        targetContainerIds);
+  }
+
+  private Set<Long> getContainersFromLocations(
+      List<OmKeyLocationInfoGroup> locationVersions, Set<Long> targetContainerIds) {
+    Set<Long> matchedContainers = new HashSet<>();
+    locationVersions.forEach(
         e -> e.getLocationList().forEach(
             blk -> {
               long cid = blk.getBlockID().getContainerID();
               if (targetContainerIds.contains(cid)) {
-                keyContainers.add(cid);
+                matchedContainers.add(cid);
               }
             }));
-    return keyContainers;
+    return matchedContainers;
   }
 
   private void prepareDirIdTree(Map<Long, Pair<Long, String>> bucketVolMap) throws Exception {

--- a/hadoop-ozone/cli-debug/src/test/java/org/apache/hadoop/ozone/debug/om/TestContainerToKeyMapping.java
+++ b/hadoop-ozone/cli-debug/src/test/java/org/apache/hadoop/ozone/debug/om/TestContainerToKeyMapping.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.debug.OzoneDebug;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
@@ -41,6 +42,8 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartKeyInfo;
@@ -83,6 +86,10 @@ public class TestContainerToKeyMapping {
   private static final long MPU_KEY_ID = 700L;
   private static final long MPU_PART1_ID = 710L;
   private static final long MPU_PART2_ID = 720L;
+  private static final long CONTAINER_ID_5 = 5L;
+  private static final long MPU_V1_KEY_ID = 750L;
+  private static final long MPU_V1_PART1_ID = 760L;
+  private static final long MPU_V1_PART2_ID = 770L;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -190,7 +197,19 @@ public class TestContainerToKeyMapping {
   }
 
   @Test
+  public void testContainerToKeyMappingWithV1MPU() {
+    int exitCode = execute("--containers", String.valueOf(CONTAINER_ID_5), "--in-progress");
+    assertEquals(0, exitCode);
 
+    String output = outWriter.toString();
+
+    // Parts of the schemaVersion 1 MPU are found via the split parts table.
+    assertThat(output).contains("\"" + CONTAINER_ID_5 + "\"");
+    assertThat(output).contains("\"openKeys\"");
+    assertThat(output).contains("/vol1/obs-bucket/mpuKeyV1/v1-upload-id");
+  }
+
+  @Test
   public void testNonExistentContainer() {
     long nonExistentContainerId = 999L;
     
@@ -292,6 +311,9 @@ public class TestContainerToKeyMapping {
 
     // Create MPU (multipart upload) for OBS bucket with parts in container 5
     createMultipartUpload();
+
+    // Create a schemaVersion 1 MPU whose parts live in the split parts table.
+    createV1MultipartUpload();
   }
 
   /**
@@ -337,6 +359,66 @@ public class TestContainerToKeyMapping {
     String mpuKey = omMetadataManager.getMultipartKey(
         VOLUME_NAME, OBS_BUCKET_NAME, mpuKeyName, uploadId);
     omMetadataManager.getMultipartInfoTable().put(mpuKey, mpuInfo);
+  }
+
+  /**
+   * Helper method to create a schemaVersion 1 multipart upload: the inline part
+   * map is empty and the parts live in the dedicated multipartPartsTable.
+   */
+  private void createV1MultipartUpload() throws Exception {
+    String mpuKeyName = "mpuKeyV1";
+    String uploadId = "v1-upload-id";
+
+    OmMultipartPartInfo part1 = createPart(
+        mpuKeyName + "/" + uploadId + "/part-1", 1, MPU_V1_PART1_ID, CONTAINER_ID_5);
+    OmMultipartPartInfo part2 = createPart(
+        mpuKeyName + "/" + uploadId + "/part-2", 2, MPU_V1_PART2_ID, CONTAINER_ID_5);
+
+    OmMultipartKeyInfo mpuInfo = new OmMultipartKeyInfo.Builder()
+        .setUploadID(uploadId)
+        .setCreationTime(System.currentTimeMillis())
+        .setReplicationConfig(StandaloneReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE))
+        .setPartKeyInfoList(Collections.emptySortedMap())
+        .setObjectID(MPU_V1_KEY_ID)
+        .setParentID(0)
+        .setUpdateID(1)
+        .setSchemaVersion((byte) 1)
+        .build();
+
+    String mpuKey = omMetadataManager.getMultipartKey(
+        VOLUME_NAME, OBS_BUCKET_NAME, mpuKeyName, uploadId);
+    omMetadataManager.getMultipartInfoTable().put(mpuKey, mpuInfo);
+    omMetadataManager.getMultipartPartsTable().put(
+        OmMultipartPartKey.of(uploadId, 1), part1);
+    omMetadataManager.getMultipartPartsTable().put(
+        OmMultipartPartKey.of(uploadId, 2), part2);
+  }
+
+  /**
+   * Helper method to create a split-table part with a block in a container.
+   */
+  private OmMultipartPartInfo createPart(String partName, int partNumber,
+      long objectId, long containerId) {
+    OmKeyLocationInfo locationInfo = new OmKeyLocationInfo.Builder()
+        .setBlockID(new BlockID(containerId, 1L))
+        .setLength(1024)
+        .setOffset(0)
+        .build();
+    OmKeyInfo partKeyInfo = new OmKeyInfo.Builder()
+        .setVolumeName(VOLUME_NAME)
+        .setBucketName(OBS_BUCKET_NAME)
+        .setKeyName(partName)
+        .setReplicationConfig(StandaloneReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE))
+        .setDataSize(1024)
+        .setObjectID(objectId)
+        .setUpdateID(1)
+        .setCreationTime(System.currentTimeMillis())
+        .setModificationTime(System.currentTimeMillis())
+        .addOmKeyLocationInfoGroup(new OmKeyLocationInfoGroup(0,
+            Collections.singletonList(locationInfo)))
+        .addMetadata(OzoneConsts.ETAG, "etag-" + partNumber)
+        .build();
+    return OmMultipartPartInfo.from(partName, partNumber, partKeyInfo);
   }
 
   /**


### PR DESCRIPTION
## Stack

PR 8 of the HDDS-14661 write/read split, stacked on PR 7 (`HDDS-14661-7-integration-test`). Closes the last non-Recon production reader of the inline part map.

## What

`ozone debug om container-key-mapping --in-progress` maps target containers to the in-progress multipart uploads holding their blocks, by iterating each upload's **inline** `getPartKeyInfoMap()`. After finalization (`schemaVersion == 1`) that inline map is empty — the parts live in the split parts table — so the tool **silently missed** every in-progress v1 upload's part blocks.

## Fix

Open the `multipartPartsTable` from the OM DB and, for `schemaVersion == 1` uploads, resolve part containers by scanning that table by `uploadId`. The v0 path is unchanged. The block→container logic is factored into a shared `getContainersFromLocations(List<OmKeyLocationInfoGroup>, ...)` used by both the inline (`OmKeyInfo`) and split-table (`OmMultipartPartInfo`) paths.

A plain prefix scan is correct here (unlike the OM apply path): this tool reads a **static offline RocksDB**, not a live OM, so there is no cache to merge.

## Tests

Adds `testContainerToKeyMappingWithV1MPU` to `TestContainerToKeyMapping`: seeds a schemaVersion-1 MPU with parts written directly to the split table (in an isolated container so existing cases are unaffected) and asserts the tool maps that container to the upload. The existing 7 cases (including the v0 inline-MPU case) still pass — verifying the shared-helper refactor introduced no regression. Run locally: **8/8 pass, checkstyle clean** (this offline harness runs without a cluster).