### PR TITLE
HDDS-14666. Account for split-table parts in Recon multipart insights

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/MultipartInfoInsightHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/MultipartInfoInsightHandler.java
@@ -24,6 +24,9 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
+import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartKeyInfo;
 import org.apache.hadoop.ozone.recon.api.types.ReconBasicOmKeyInfo;
 import org.slf4j.Logger;
@@ -32,6 +35,14 @@ import org.slf4j.LoggerFactory;
 /**
  * Manages records in the MultipartInfo Table, updating counts and sizes of
  * multipart upload keys in the backend.
+ *
+ * <p>For schemaVersion 1 uploads the per-part records live in the separate
+ * multipartPartsTable rather than inline in the multipartInfoTable row, so the
+ * reprocess path ({@link #getTableSizeAndCount}) reads their sizes from that
+ * table, deriving the replicated size from the parent upload's replication
+ * config. The incremental event path observes only multipartInfoTable events,
+ * whose inline part list is empty for v1 uploads, so v1 part sizes are
+ * reflected after the next reprocess.</p>
  */
 public class MultipartInfoInsightHandler implements OmTableHandler {
 
@@ -163,10 +174,31 @@ public class MultipartInfoInsightHandler implements OmTableHandler {
         Table.KeyValue<String, OmMultipartKeyInfo> kv = iterator.next();
         if (kv != null && kv.getValue() != null) {
           OmMultipartKeyInfo multipartKeyInfo = kv.getValue();
-          for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
-            ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
-            unReplicatedSize += omKeyInfo.getDataSize();
-            replicatedSize += omKeyInfo.getReplicatedSize();
+          if (multipartKeyInfo.getSchemaVersion() == 0) {
+            for (PartKeyInfo partKeyInfo : multipartKeyInfo.getPartKeyInfoMap()) {
+              ReconBasicOmKeyInfo omKeyInfo = ReconBasicOmKeyInfo.getFromProtobuf(partKeyInfo.getPartKeyInfo());
+              unReplicatedSize += omKeyInfo.getDataSize();
+              replicatedSize += omKeyInfo.getReplicatedSize();
+            }
+          } else {
+            // schemaVersion 1: parts live in the split parts table. Part rows
+            // carry no replication config, so derive the replicated size from
+            // the parent upload's replication config -- mirroring how the
+            // inline PartKeyInfo's KeyInfo carries it for schemaVersion 0.
+            try (Table.KeyValueIterator<OmMultipartPartKey, OmMultipartPartInfo> partIterator =
+                omMetadataManager.getMultipartPartsTable().iterator(
+                    OmMultipartPartKey.prefix(multipartKeyInfo.getUploadID()))) {
+              while (partIterator.hasNext()) {
+                OmMultipartPartInfo part = partIterator.next().getValue();
+                if (part == null
+                    || multipartKeyInfo.getReplicationConfig() == null) {
+                  continue;
+                }
+                unReplicatedSize += part.getDataSize();
+                replicatedSize += QuotaUtil.getReplicatedSize(
+                    part.getDataSize(), multipartKeyInfo.getReplicationConfig());
+              }
+            }
           }
           count++;
         }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmTableInsightTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOmTableInsightTask.java
@@ -52,18 +52,24 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TypedTable;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyInfo;
@@ -781,6 +787,109 @@ public class TestOmTableInsightTask extends AbstractReconSqlDBTest {
     assertEquals(300L, getUnReplicatedSizeForTable(MULTIPART_INFO_TABLE));
     // each MPU part is replicated using RATIS THREE, total replicated size = 300 bytes * 3 = 900 bytes.
     assertEquals(900L, getReplicatedSizeForTable(MULTIPART_INFO_TABLE));
+  }
+
+  @Test
+  public void testReprocessForMultipartInfoTableSchemaVersion1() throws Exception {
+    // schemaVersion 1 upload: the inline part list is empty and the parts live
+    // in the split multipartPartsTable. Reprocess must read their sizes from
+    // there and derive the replicated size from the parent upload's replication
+    // config, matching the schemaVersion 0 result for equivalent parts.
+    String uploadID = UUID.randomUUID().toString();
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    OmMultipartKeyInfo omMultipartKeyInfo = new OmMultipartKeyInfo.Builder()
+        .setObjectID(1L)
+        .setUploadID(uploadID)
+        .setCreationTime(Time.now())
+        .setReplicationConfig(RatisReplicationConfig.getInstance(
+            HddsProtos.ReplicationFactor.THREE))
+        .setSchemaVersion((byte) 1)
+        .build();
+    String multipartKey = reconOMMetadataManager.getMultipartKey(
+        volumeName, bucketName, keyName, uploadID);
+    reconOMMetadataManager.getMultipartInfoTable().put(multipartKey, omMultipartKeyInfo);
+
+    // Three 100-byte parts in the split table; the inline list stays empty.
+    for (int partNumber = 1; partNumber <= 3; partNumber++) {
+      reconOMMetadataManager.getMultipartPartsTable().put(
+          OmMultipartPartKey.of(uploadID, partNumber),
+          createSplitPart(partNumber, 100L));
+    }
+
+    ReconOmTask.TaskResult result = omTableInsightTask.reprocess(reconOMMetadataManager);
+    assertTrue(result.isTaskSuccess());
+
+    assertEquals(1L, getCountForTable(MULTIPART_INFO_TABLE));
+    // 3 parts * 100 bytes = 300 bytes unreplicated.
+    assertEquals(300L, getUnReplicatedSizeForTable(MULTIPART_INFO_TABLE));
+    // RATIS THREE -> 300 * 3 = 900 bytes replicated.
+    assertEquals(900L, getReplicatedSizeForTable(MULTIPART_INFO_TABLE));
+  }
+
+  @Test
+  public void testProcessForMultipartInfoTableSchemaVersion1() throws Exception {
+    // A schemaVersion 1 upload's parts live in the split table, so a
+    // multipartInfoTable PUT/DELETE event carries an empty inline list. The
+    // incremental path must handle it without error: the upload is counted, and
+    // the part sizes (tracked via the split table) are reflected at reprocess,
+    // not from these events.
+    String uploadID = UUID.randomUUID().toString();
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+    OmMultipartKeyInfo mpu = new OmMultipartKeyInfo.Builder()
+        .setObjectID(1L)
+        .setUploadID(uploadID)
+        .setCreationTime(Time.now())
+        .setReplicationConfig(RatisReplicationConfig.getInstance(
+            HddsProtos.ReplicationFactor.THREE))
+        .setSchemaVersion((byte) 1)
+        .build();
+    String multipartKey = reconOMMetadataManager.getMultipartKey(
+        volumeName, bucketName, keyName, uploadID);
+
+    ArrayList<OMDBUpdateEvent> putEvents = new ArrayList<>();
+    putEvents.add(getOMUpdateEvent(multipartKey, mpu, MULTIPART_INFO_TABLE, PUT, null));
+    omTableInsightTask.process(new OMUpdateEventBatch(putEvents, 0L), Collections.emptyMap());
+
+    // The upload is counted; size stays 0 incrementally (split-table parts are
+    // accounted at reprocess, see testReprocessForMultipartInfoTableSchemaVersion1).
+    assertEquals(1L, getCountForTable(MULTIPART_INFO_TABLE));
+    assertEquals(0L, getUnReplicatedSizeForTable(MULTIPART_INFO_TABLE));
+    assertEquals(0L, getReplicatedSizeForTable(MULTIPART_INFO_TABLE));
+
+    // DELETE handles the empty inline list without error and decrements count.
+    ArrayList<OMDBUpdateEvent> deleteEvents = new ArrayList<>();
+    deleteEvents.add(getOMUpdateEvent(multipartKey, mpu, MULTIPART_INFO_TABLE, DELETE, null));
+    omTableInsightTask.process(new OMUpdateEventBatch(deleteEvents, 0L), Collections.emptyMap());
+    assertEquals(0L, getCountForTable(MULTIPART_INFO_TABLE));
+  }
+
+  private OmMultipartPartInfo createSplitPart(int partNumber, long dataSize) {
+    OmKeyInfo partKeyInfo = new OmKeyInfo.Builder()
+        .setVolumeName("vol")
+        .setBucketName("bucket")
+        .setKeyName("key")
+        .setReplicationConfig(RatisReplicationConfig.getInstance(
+            HddsProtos.ReplicationFactor.THREE))
+        .setOmKeyLocationInfos(Collections.singletonList(
+            new OmKeyLocationInfoGroup(0, Collections.singletonList(
+                new OmKeyLocationInfo.Builder()
+                    .setBlockID(new BlockID(partNumber, partNumber))
+                    .setLength(dataSize)
+                    .setOffset(0)
+                    .build()))))
+        .setDataSize(dataSize)
+        .setCreationTime(Time.now())
+        .setModificationTime(Time.now())
+        .setObjectID(partNumber)
+        .setUpdateID(1)
+        .addMetadata(OzoneConsts.ETAG, "etag-" + partNumber)
+        .build();
+    return OmMultipartPartInfo.from("part-" + partNumber, partNumber, partKeyInfo);
   }
 
   public PartKeyInfo createPartKeyInfo(String volumeName, String bucketName,


### PR DESCRIPTION
## Stack

PR 11 of the HDDS-14661 split, stacked on PR 10 (`HDDS-14661-10-runbook`). This is the deferred-last functional piece (HDDS-14666) — the final code-path reader of multipart parts.

## What

Recon's `MultipartInfoInsightHandler` computed multipart upload sizes by iterating each upload's **inline** part list. For schemaVersion 1 uploads that list is empty (parts live in the split `multipartPartsTable`), so Recon under-counted their unreplicated and replicated sizes.

## Fix (no sync/schema change needed)

The scoping confirmed Recon already syncs the parts table: it opens the OM checkpoint with the full `OMDBDefinition` (which includes `MULTIPART_PARTS_TABLE_DEF`), and `ReconOmMetadataManagerImpl` inherits `getMultipartPartsTable()`. So the fix is localized to the handler:

- **Reprocess** (`getTableSizeAndCount`, the authoritative periodic recompute) branches on `schemaVersion`: v0 keeps inline accounting; **v1 scans `multipartPartsTable` for the upload's parts** and sums their sizes, deriving the replicated size from the **parent upload's** replication config — the part rows carry none, so this mirrors how the inline `PartKeyInfo`'s `KeyInfo` provides it for v0.
- **Incremental** event path is unchanged and **safe** for v1: `getPartKeyInfoMap()` returns an empty (non-null) map for v1, so a `multipartInfoTable` event counts the upload and adds zero size; the part sizes are reflected at the next reprocess. This is documented on the handler.

## Why replicated size is reprocess-only for v1

The split part row stores no replication config, and incremental `multipartPartsTable` events carry no parent context — so the replicated size can only be computed where the parent is in hand, i.e. the info-table reprocess. This matches Recon's existing eventual-consistency model (reprocess runs on each OM snapshot sync).

## Tests (offline, no cluster)

- `testReprocessForMultipartInfoTableSchemaVersion1`: a v1 upload with 3×100B RATIS-THREE parts in the split table reprocesses to **300 unreplicated / 900 replicated** — identical to the equivalent v0 case.
- `testProcessForMultipartInfoTableSchemaVersion1`: a v1 `multipartInfoTable` PUT then DELETE counts the upload (1 → 0) and adds zero size, without error.
- Existing v0 tests unchanged. Verified locally: **4/4 pass, checkstyle clean.**