### PR TITLE
HDDS-14661. Document and test the native-client eTag-less multipart contract

### DIFF
--- a/hadoop-hdds/docs/content/design/multipart-parts-table-split.md
+++ b/hadoop-hdds/docs/content/design/multipart-parts-table-split.md
@@ -88,6 +88,37 @@ defect.
   collection (deleted-table entries on overwrite, complete-with-discards, and
   abort) are byte-for-byte identical between the two layouts.
 
+# ETags and non-S3 clients
+
+The part ETag is an S3 concept, and only the S3 gateway computes its value (the
+content MD5); the Ozone Manager and the generic Ozone client never derive it --
+they store, validate, and concatenate whatever string they are handed. This
+matters because multipart upload is also reachable through the **native Ozone
+client**, which does not set an ETag at all. Both schemaVersion 0 and 1 tolerate
+such eTag-less parts (this feature deliberately did not change that), so:
+
+- **S3 uploads** get the canonical, content-derived multipart ETag:
+  `md5(concat(per-part content MD5s)) + "-<partCount>"`.
+- **Native (non-S3) uploads** complete successfully but their final-object ETag
+  is **identifier-derived, not content-derived**:
+  `md5(concat(part names)) + "-<partCount>"`. It is a stable, valid S3-shaped
+  ETag but carries no content-integrity meaning, and it differs from the value
+  an S3 upload of byte-identical content would produce.
+
+Two pieces of code make the native path work and are easy to mistake for dead
+defensiveness; both carry cross-reference comments so they are not removed:
+
+1. `OmMultipartUploadCompleteList#getPartsList` mirrors the supplied per-part
+   identifier into BOTH the proto `partName` and `eTag` fields, so a native
+   (eTag-less) Complete still satisfies the OM's `allMatch(Part::hasETag)` gate.
+2. `S3MultipartUploadCompleteRequest#eTagBasedValidator` accepts a part when the
+   supplied value matches the stored eTag **or** the stored part name; native
+   parts (no stored eTag) pass only via the part-name clause.
+
+Making native-client multipart ETags content-derived (computing the MD5 in the
+client output stream, the only layer below the gateway that sees the bytes) is a
+tracked follow-up (`TODO(HDDS-14661 follow-up)`); it is out of scope here.
+
 # The one-way door
 
 **Finalization cannot be undone, and it removes the ability to downgrade the OM

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartUploadCompleteList.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmMultipartUploadCompleteList.java
@@ -54,9 +54,22 @@ public class OmMultipartUploadCompleteList {
    */
   public List<Part> getPartsList() {
     List<Part> partList = new ArrayList<>();
-    multipartMap.forEach((partNumber, eTag) -> partList.add(Part
-        // set partName equal to eTag for back compatibility (partName is a required property)
-        .newBuilder().setPartName(eTag).setETag(eTag).setPartNumber(partNumber).build()));
+    // Each map value is the per-part identifier the caller supplied at Complete:
+    // for an S3 client it is the part's MD5 eTag; for the native Ozone client
+    // (which never computes an eTag) it is the part NAME. We populate BOTH the
+    // proto partName and eTag fields from that single value. Two reasons:
+    //   1. partName is a required proto field, so it must be set.
+    //   2. CONTRACT (load-bearing for the HDDS-14661 eTag-less multipart path):
+    //      the OM's CompleteMultipartUpload validator takes its eTag-based path
+    //      only when EVERY Part has an eTag (Part::hasETag). Mirroring the value
+    //      into eTag here keeps a native, eTag-less upload on that path, where it
+    //      passes via the validator's "request eTag equals the stored part name"
+    //      fallback. See S3MultipartUploadCompleteRequest#eTagBasedValidator.
+    // Do NOT stop populating eTag here without updating that validator: a native
+    // multipart Complete would then fail every part with INVALID_PART.
+    multipartMap.forEach((partNumber, partIdentifier) -> partList.add(Part
+        .newBuilder().setPartName(partIdentifier).setETag(partIdentifier)
+        .setPartNumber(partNumber).build()));
     return partList;
   }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartUploadCompleteList.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartUploadCompleteList.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Part;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link OmMultipartUploadCompleteList}.
+ */
+public class TestOmMultipartUploadCompleteList {
+
+  /**
+   * Pins the HDDS-14661 eTag-less-multipart contract: getPartsList() must
+   * populate BOTH the proto partName and eTag fields from the single per-part
+   * identifier the caller supplied.
+   *
+   * <p>For an S3 client that identifier is the part's MD5 eTag; for the native
+   * Ozone client (which computes no eTag) it is the part NAME. Mirroring it into
+   * the eTag field is what keeps a native, eTag-less Complete on the OM's
+   * eTag-based validator path (which it enters only when every Part hasETag) --
+   * where it then passes via that validator's stored-part-name fallback. If this
+   * mirroring is dropped, native multipart Complete fails every part with
+   * INVALID_PART, so this test guards against that regression.</p>
+   */
+  @Test
+  public void testGetPartsListMirrorsIdentifierIntoPartNameAndETag() {
+    Map<Integer, String> partMap = new LinkedHashMap<>();
+    partMap.put(1, "part-identifier-1");
+    partMap.put(2, "part-identifier-2");
+
+    List<Part> parts =
+        new OmMultipartUploadCompleteList(partMap).getPartsList();
+
+    assertEquals(2, parts.size());
+    for (Part part : parts) {
+      assertTrue(part.hasETag(),
+          "every Part must carry an eTag so the OM eTag-based validator path is "
+              + "taken (load-bearing for native eTag-less Complete)");
+      assertEquals(part.getPartName(), part.getETag(),
+          "partName and eTag must mirror the same supplied identifier");
+    }
+    assertEquals("part-identifier-1", parts.get(0).getPartName());
+    assertEquals("part-identifier-1", parts.get(0).getETag());
+    assertEquals(1, parts.get(0).getPartNumber());
+    assertEquals("part-identifier-2", parts.get(1).getETag());
+    assertEquals(2, parts.get(1).getPartNumber());
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -100,6 +100,14 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
               .findFirst().ifPresent(kv -> dbPartETag.set(kv.getValue()));
           dbPartName = partKeyInfo.getPartName();
         }
+        // A part is valid if the value supplied at Complete matches EITHER the
+        // stored part eTag OR the stored part name. The "|| stored part name"
+        // clause is load-bearing for the HDDS-14661 eTag-less multipart path:
+        // a native Ozone client commits parts with no eTag (dbPartETag == null)
+        // and supplies the part name at Complete (mirrored into the eTag field
+        // by OmMultipartUploadCompleteList#getPartsList), so the match succeeds
+        // only via this fallback. Do NOT drop it as redundant defensiveness --
+        // native multipart Complete would then fail every part with INVALID_PART.
         return new MultipartCommitRequestPart(eTag, partKeyInfo == null ? null :
             dbPartETag.get(), StringUtils.equals(eTag, dbPartETag.get()) || StringUtils.equals(eTag, dbPartName));
       };

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
@@ -28,7 +28,9 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -40,12 +42,15 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartPartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartPartKey;
+import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteList;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartCommitUploadPartRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Part;
 import org.apache.hadoop.util.Time;
@@ -195,6 +200,97 @@ public class TestS3MultipartUploadCompleteRequest
     // The split-table part row was deleted on completion.
     assertNull(omMetadataManager.getMultipartPartsTable()
         .get(OmMultipartPartKey.of(multipartUploadID, 1)));
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheV1NativeETaglessComplete()
+      throws Exception {
+    // Native (non-S3) multipart upload, schemaVersion 1, end to end. The native
+    // Ozone client commits parts with NO eTag (only the S3 gateway computes one)
+    // and at Complete supplies each part NAME, which OmMultipartUploadCompleteList
+    // mirrors into both the partName and eTag proto fields. This exercises the
+    // load-bearing eTag-less contract: the OM must (a) accept the eTag-less
+    // commit, (b) validate each part via the "eTag equals the stored part name"
+    // fallback in eTagBasedValidator, and (c) derive the final-object ETag from
+    // the part NAMES -- md5(concat(partNames))-N -- not from content MD5s.
+    when(ozoneManager.getVersionManager().getMetadataLayoutVersion())
+        .thenReturn(OMLayoutFeature.MPU_PARTS_TABLE_SPLIT.layoutVersion());
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = getKeyName();
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, getBucketLayout());
+
+    OMRequest initiateMPURequest =
+        doPreExecuteInitiateMPU(volumeName, bucketName, keyName);
+    String multipartUploadID =
+        getS3InitiateMultipartUploadReq(initiateMPURequest)
+            .validateAndUpdateCache(ozoneManager, 1L).getOMResponse()
+            .getInitiateMultiPartUploadResponse().getMultipartUploadID();
+
+    // Commit one part as the NATIVE client does -- with NO eTag. Build the
+    // normal commit request and strip the ETag metadata that the S3 gateway
+    // would have set, then preExecute. The schemaVersion 1 commit guard requires
+    // only block locations (supplied by the open key), so the eTag-less part
+    // still commits (HDDS-14661 relaxation).
+    long clientID = Time.now();
+    OMRequest rawCommit = OMRequestTestUtils.createCommitPartMPURequest(
+        volumeName, bucketName, keyName, clientID, 0L, multipartUploadID, 1,
+        Collections.emptyList());
+    MultipartCommitUploadPartRequest commitPart =
+        rawCommit.getCommitMultiPartUploadRequest();
+    OMRequest eTaglessCommit = rawCommit.toBuilder()
+        .setCommitMultiPartUploadRequest(commitPart.toBuilder().setKeyArgs(
+            commitPart.getKeyArgs().toBuilder().clearMetadata().build()))
+        .build();
+    OMRequest commitMultipartRequest =
+        getS3MultipartUploadCommitReq(eTaglessCommit).preExecute(ozoneManager);
+    S3MultipartUploadCommitPartRequest commitReq =
+        getS3MultipartUploadCommitReq(commitMultipartRequest);
+    addKeyToTable(volumeName, bucketName, keyName, clientID);
+    OMClientResponse commitResp =
+        commitReq.validateAndUpdateCache(ozoneManager, 2L);
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        commitResp.getOMResponse().getStatus());
+
+    // The committed split-table part carries no eTag.
+    OmMultipartPartInfo storedPart = omMetadataManager.getMultipartPartsTable()
+        .get(OmMultipartPartKey.of(multipartUploadID, 1));
+    assertNotNull(storedPart);
+    assertNull(storedPart.getETag());
+
+    // Complete as the native client does: supply the part NAME, which
+    // OmMultipartUploadCompleteList mirrors into both partName and eTag.
+    String partName = storedPart.getPartName();
+    Map<Integer, String> nativePartsMap = new LinkedHashMap<>();
+    nativePartsMap.put(1, partName);
+    List<Part> partList =
+        new OmMultipartUploadCompleteList(nativePartsMap).getPartsList();
+
+    OMRequest completeMultipartRequest = doPreExecuteCompleteMPU(volumeName,
+        bucketName, keyName, multipartUploadID, partList);
+    S3MultipartUploadCompleteRequest completeReq =
+        getS3MultipartUploadCompleteReq(completeMultipartRequest);
+    OMClientResponse omClientResponse =
+        completeReq.validateAndUpdateCache(ozoneManager, 3L);
+    BatchOperation batchOperation =
+        omMetadataManager.getStore().initBatchOperation();
+    omClientResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+
+    // Complete succeeds for the eTag-less native upload (validated via the
+    // eTag-equals-stored-part-name fallback)...
+    assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+    // ...and the final-object ETag is identifier-derived from the part name,
+    // not content-derived.
+    OmKeyInfo finalKey = omMetadataManager
+        .getKeyTable(completeReq.getBucketLayout())
+        .get(getOzoneDBKey(volumeName, bucketName, keyName));
+    assertNotNull(finalKey);
+    assertEquals(DigestUtils.md5Hex(partName) + "-1",
+        finalKey.getMetadata().get(OzoneConsts.ETAG));
   }
 
   /** Commits one part of a schemaVersion 1 upload and returns its eTag. */


### PR DESCRIPTION
## What

Multipart upload reaches the OM through both the **S3 gateway** and the **native Ozone client**. The part ETag is an S3 concept -- only the S3 gateway computes its value (the content MD5) and stores it as `ETAG` metadata; the OM and the generic client never derive it. The native client sets no ETag at all.

Earlier in this stack the schemaVersion 1 commit guard was relaxed to require only block locations (not an eTag), letting a native, eTag-less multipart part commit and complete -- exactly as the legacy schemaVersion 0 (inline) path always did. **This PR does not change that behavior.** It makes the contract that keeps it working explicit, tested, and documented, because the load-bearing code is currently easy to mistake for removable dead defensiveness.

## The contract (two coupled spots)

A native, eTag-less multipart Complete succeeds only because of two pieces of code, in different files:

1. **`OmMultipartUploadCompleteList#getPartsList`** mirrors each supplied per-part identifier into **both** the proto `partName` and `eTag` fields. For a native upload that identifier is the part *name*; mirroring it into `eTag` keeps the upload on the OM's eTag-based Complete validator, which is entered only when *every* `Part` carries an eTag (`allMatch(Part::hasETag)`).
2. **`S3MultipartUploadCompleteRequest#eTagBasedValidator`** accepts a part when the supplied value equals the stored eTag **or** the stored part name. A native part has no stored eTag (`dbPartETag == null`), so it passes *only* via the part-name clause.

Remove either and a native multipart Complete fails every part with `INVALID_PART`. Nothing tested or documented this -- a future "cleanup" of either spot would silently break native multipart upload.

## What this PR adds

- **Cross-reference comments** at both code sites above, explaining the coupling and warning against removal. (Comment-only; no behavior change.)
- **`TestOmMultipartUploadCompleteList`** -- a unit test pinning that `getPartsList` mirrors the identifier into both `partName` and `eTag`.
- **`TestS3MultipartUploadCompleteRequest#testValidateAndUpdateCacheV1NativeETaglessComplete`** -- an end-to-end case that commits an eTag-less part (modelling the native client) and completes it, asserting (a) the commit succeeds, (b) the stored part has no eTag, (c) Complete succeeds via the part-name fallback, and (d) the final-object ETag is **identifier-derived** (`md5(concat(part names)) + "-<count>"`), not content-derived.
- A **design-doc section** ("ETags and non-S3 clients") recording that native multipart ETags are identifier-derived (S3 uploads remain content-derived), and pointing at the eTag-hardening follow-up.

## Why identifier-derived (and the follow-up)

The OM cannot compute a content MD5 -- only the writer with the bytes can, and on the native path that layer (the client output stream) does not. So a native multipart object's ETag is a stable, valid S3-shaped value but not a content fingerprint, and it differs from what an S3 upload of identical bytes would produce. Making it content-derived (computing the MD5 in the client output stream, the only layer below the gateway that sees the bytes) is a tracked follow-up (`TODO(HDDS-14661 follow-up)`), out of scope here.

## Testing

- `TestOmMultipartUploadCompleteList` -- green.
- `TestS3MultipartUploadCompleteRequest` (incl. the new native eTag-less case) -- 11/11 green.
- `checkstyle` / `pmd` / `spotbugs` clean on `hadoop-ozone/common` and `hadoop-ozone/ozone-manager`.

Comments, tests, and docs only -- no production behavior change.