### PR TITLE
HDDS-14661. Enforce multipart part replication matches the upload

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -1105,6 +1105,14 @@ public abstract class OMKeyRequest extends OMClientRequest {
     }
     // For this upload part we don't need to check in KeyTable. As this
     // is not an actual key, it is a part of the key.
+    // Invariant (HDDS-14661): a multipart part always inherits its upload's
+    // replication config -- taken here from the upload's open key (partKeyInfo),
+    // NOT from the client-supplied args. Every part of an upload therefore
+    // shares one replication config, which the schemaVersion 1 split parts table
+    // relies on: part rows store no replication, so Complete/abort/Recon derive
+    // a part's size from the upload's config. This is the primary enforcement;
+    // S3MultipartUploadCommitPartRequest re-checks it at commit as
+    // defense-in-depth.
     return createFileInfo(args, locations, partKeyInfo.getReplicationConfig(),
             size, encInfo, prefixManager, omBucketInfo, omPathInfo,
             transactionLogIndex, objectID, configuration);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -26,6 +26,7 @@ import java.nio.file.InvalidPathException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
@@ -201,6 +202,25 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
         throw new OMException("MPU parts-table split behavior is not allowed " +
           "before cluster finalization for commit part request.",
           OMException.ResultCodes.NOT_SUPPORTED_OPERATION_PRIOR_FINALIZATION);
+      }
+
+      // Invariant (HDDS-14661): every part of a multipart upload must use the
+      // same replication config as the upload. The OM already forces this at
+      // part-open (OMKeyRequest.prepareMultipartFileInfo derives the part's
+      // replication from the MPU's open key and discards any client value), and
+      // schemaVersion 1 cannot represent a divergent part (the parts table holds
+      // no per-part replication -- Complete/abort/Recon all derive a part's size
+      // from the upload's config). This is the belt-and-suspenders check at the
+      // commit boundary: reject a part whose replication still differs so no
+      // future path that bypasses that inheritance can persist a part the v1
+      // readers would mis-account.
+      if (!Objects.equals(omKeyInfo.getReplicationConfig(),
+          multipartKeyInfo.getReplicationConfig())) {
+        throw new OMException("Multipart part " + partNumber
+            + " replication config " + omKeyInfo.getReplicationConfig()
+            + " does not match the multipart upload replication config "
+            + multipartKeyInfo.getReplicationConfig(),
+            OMException.ResultCodes.INVALID_REQUEST);
       }
 
       // Resolve the previously-committed part (if this part number is being

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
@@ -32,8 +32,9 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.audit.AuditLogger;
@@ -100,8 +101,12 @@ public class TestS3MultipartRequest {
     when(ozoneManager.getAccessAuthorizer())
         .thenReturn(new OzoneNativeAuthorizer());
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
+    // These MPU unit tests stage parts as RATIS/ONE, so make the resolved
+    // upload replication RATIS/ONE too: a multipart part must always carry the
+    // same replication config as its upload, which CommitPart now enforces
+    // (HDDS-14661). The cluster default would otherwise be RATIS/THREE.
     when(ozoneManager.getDefaultReplicationConfig()).thenReturn(
-        ReplicationConfig.getDefault(ozoneConfiguration));
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE));
     doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
     when(ozoneManager.resolveBucketLink(any(KeyArgs.class),
         any(OMClientRequest.class)))

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
@@ -131,6 +132,46 @@ public class TestS3MultipartUploadCommitPartRequest
     assertNull(omMetadataManager
         .getOpenKeyTable(s3MultipartUploadCommitPartRequest.getBucketLayout())
         .get(partKey));
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheRejectsPartReplicationMismatch()
+      throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = getKeyName();
+
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, getBucketLayout());
+    createParentPath(volumeName, bucketName);
+
+    OMRequest initiateMPURequest = doPreExecuteInitiateMPU(volumeName,
+        bucketName, keyName);
+    OMClientResponse initiateResponse = getS3InitiateMultipartUploadReq(
+        initiateMPURequest).validateAndUpdateCache(ozoneManager, 1L);
+    String multipartUploadID = initiateResponse.getOMResponse()
+        .getInitiateMultiPartUploadResponse().getMultipartUploadID();
+
+    long clientID = Time.now();
+    OMRequest commitMultipartRequest = doPreExecuteCommitMPU(volumeName,
+        bucketName, keyName, clientID, multipartUploadID, 1);
+    S3MultipartUploadCommitPartRequest s3MultipartUploadCommitPartRequest =
+        getS3MultipartUploadCommitReq(commitMultipartRequest);
+
+    // The upload resolved to RATIS/ONE (test cluster default). Stage the part's
+    // open key with a DIFFERENT replication (RATIS/THREE). A real client cannot
+    // do this -- the OM forces parts to inherit the upload's config at part-open
+    // -- but a bug or a future code path could. CommitPart must reject it so the
+    // v1 part accounting (which derives a part's size from the upload's config)
+    // can never silently mis-account a divergent part (HDDS-14661).
+    addKeyToOpenKeyTable(volumeName, bucketName, keyName, clientID,
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
+
+    OMClientResponse omClientResponse = s3MultipartUploadCommitPartRequest
+        .validateAndUpdateCache(ozoneManager, 2L);
+
+    assertSame(OzoneManagerProtocolProtos.Status.INVALID_REQUEST,
+        omClientResponse.getOMResponse().getStatus());
   }
 
   @Test
@@ -919,8 +960,15 @@ public class TestS3MultipartUploadCommitPartRequest
 
   protected void addKeyToOpenKeyTable(String volumeName, String bucketName,
       String keyName, long clientID) throws Exception {
+    addKeyToOpenKeyTable(volumeName, bucketName, keyName, clientID,
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE));
+  }
+
+  protected void addKeyToOpenKeyTable(String volumeName, String bucketName,
+      String keyName, long clientID, ReplicationConfig replicationConfig)
+      throws Exception {
     OMRequestTestUtils.addKeyToTable(true, true, volumeName, bucketName,
-        keyName, clientID, RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE), omMetadataManager);
+        keyName, clientID, replicationConfig, omMetadataManager);
   }
 
   protected String addKeyToOpenKeyTable(String volumeName, String bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequestWithFSO.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -74,9 +75,17 @@ public class TestS3MultipartUploadCommitPartRequestWithFSO
   @Override
   protected void addKeyToOpenKeyTable(String volumeName, String bucketName,
       String keyName, long clientID) throws Exception {
+    addKeyToOpenKeyTable(volumeName, bucketName, keyName, clientID,
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE));
+  }
+
+  @Override
+  protected void addKeyToOpenKeyTable(String volumeName, String bucketName,
+      String keyName, long clientID, ReplicationConfig replicationConfig)
+      throws Exception {
     long txnLogId = 0L;
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
-            RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE),
+            replicationConfig,
             new OmKeyLocationInfoGroup(0L, new ArrayList<>(), true))
         .setObjectID(parentID + 1)
         .setParentObjectID(parentID)


### PR DESCRIPTION
## What

Every part of a multipart upload must use the **same replication config as the upload itself**. This PR makes that invariant explicit and enforces it at the commit boundary.

Per-part replication divergence is meaningless, and under the schemaVersion 1 split parts table it is **unrepresentable**: part rows carry no replication config, so Complete, abort, and Recon all derive a part's size from the *upload's* config (`QuotaUtil.getReplicatedSize(partDataSize, uploadReplication)`). A part whose real replication differed from its upload would therefore be silently mis-accounted -- wrong quota on commit/abort, wrong sizes in Recon.

## Two layers of enforcement

1. **Part-open (already enforced; now documented).** `OMKeyRequest.prepareMultipartFileInfo` builds a part's open key from the **upload's** open-key replication and discards any client-supplied value. This holds for the S3 gateway, the native client, and `UploadPartCopy` -- all of which route part creation through this method -- so no client, however misconfigured, can persist a divergent part. Added an invariant comment at that site.
2. **Commit boundary (new, belt-and-suspenders).** `S3MultipartUploadCommitPartRequest` now rejects a part whose replication config differs from its upload's, with `INVALID_REQUEST`. Real clients never trigger this (layer 1 guarantees equality); it exists so that a *future code path* which bypasses the part-open inheritance can never land a part the v1 readers would mis-account. The check sits after the upload-exists/finalization checks and before any part staging, so it covers both schemaVersion 0 and 1 in one place.

## Why a guard if layer 1 already prevents it

Misconfigured or independently-evolving S3 gateways can process and upload parts on their own; the guard is defense against a bug (in the OM or a gateway) that would otherwise corrupt v1 quota/size accounting with no way for the split parts table to detect it (it stores no per-part replication to cross-check). It is cheap and fail-closed.

## Tests

- **Negative test** (`testValidateAndUpdateCacheRejectsPartReplicationMismatch`, OBS + FSO): stages a `RATIS/THREE` part open key under a `RATIS/ONE` upload and asserts CommitPart returns `INVALID_REQUEST`. A layout-aware `addKeyToOpenKeyTable(..., ReplicationConfig)` overload injects the divergent part in the correct key format for each layout.
- **Fixture alignment.** The multipart request unit tests previously staged `RATIS/ONE` parts under a `RATIS/THREE` (cluster-default) upload -- an inconsistency the new check exposes. The shared test base now resolves the upload replication to `RATIS/ONE`, matching the parts the tests stage. All existing multipart request tests pass unchanged otherwise.

Verified locally (JDK 8): `checkstyle` / `pmd` / `spotbugs` clean on `hadoop-ozone/ozone-manager`; all multipart request suites green (initiate/commit/complete/abort/expired-abort, OBS + FSO).

No behavior change for real clients -- the guard never fires on inputs any shipped client can produce.